### PR TITLE
Fix example by activating session before starting

### DIFF
--- a/Record/Record.cpp
+++ b/Record/Record.cpp
@@ -35,6 +35,7 @@
 
 #include <iostream>
 
+#include "PolySyncNode.hpp"
 #include "PolySyncRecordReplay.hpp"
 
 using namespace polysync;
@@ -75,6 +76,9 @@ class RecordNode : public Node
         cin >> sessionId;
         recording->setId( sessionId );
 
+        // Activate the recording session.
+        recording->activate();
+
         // Start the recording.
         recording->start();
 
@@ -106,7 +110,7 @@ class RecordNode : public Node
         // Disconnect this Node.
         disconnectPolySync();
 
-        cout << "Recording stoped." << endl;
+        cout << "Recording stopped." << endl;
     }
 };
 


### PR DESCRIPTION
Record and replay sessions require activation before starting.
This is a fix for the record example.
