### PR TITLE
Add new example to read and publish CAN data

### DIFF
--- a/CANReaderAndPublisher/CANReaderAndPublisher.cpp
+++ b/CANReaderAndPublisher/CANReaderAndPublisher.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2016 PolySync
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * \example CANReaderAndPublisher.cpp
+ *
+ * PolySync CAN API reader and publisher example.
+ *
+ * Shows how to use the CAN API to read CAN frames, and use the Messaging API
+ * to populate and publish a raw CAN frame to the bus.
+ *
+ * The example uses the standard PolySync node template and state machine.
+ * Send the SIGINT (control-C on the keyboard) signal to the node/process to do a graceful shutdown.
+ *
+ */
+
+#include <iostream>
+#include <memory>
+
+#include <PolySyncNode.hpp>
+#include <PolySyncCAN.hpp>
+#include <PolySyncDTCException.hpp>
+#include <PolySyncDataModel.hpp>
+
+
+class CANReaderAndPublisher : public polysync::Node
+{
+
+public:
+
+    CANReaderAndPublisher( uint channelID )
+        :
+        _channel( channelID, _flags )
+    {
+        // empty
+    }
+
+    virtual ~CANReaderAndPublisher() = default;
+
+protected:
+
+    /**
+     * This function is triggered once when the node has initialized in the
+     * PolySync context.
+     */
+    virtual void initStateEvent()
+    {
+        try
+        {
+            _channel.setBitRate( _bitRate );
+
+            _channel.goOnBus();
+        }
+        catch( polysync::DTCException & exception )
+        {
+            // If interaction with the channel fails, print why and trigger
+            // errorStateEvent()
+            std::cout << exception.what() << std::endl;
+
+            activateFault( exception.getDtc(), NODE_STATE_ERROR );
+        }
+    }
+
+    /**
+     * Called repeatedly while node is in an operational state. For this
+     * example, we will read CAN data, populate a PolySync CAN frame message
+     * with the incoming data, and print useful information for each frame.
+     */
+    virtual void okStateEvent()
+    {
+        try
+        {
+            // Read data from the device, timeout after one second.
+            auto payload = _channel.read( 1000000 );
+
+            std::vector < uchar > payloadVector;
+
+            payloadVector.assign( payload.begin(), payload.end() );
+
+            // Create a local CAN Frame message that we can pack with data
+            polysync::datamodel::CanFrameMessage canFrame( *this );
+
+            canFrame.setDataBuffer( payloadVector );
+
+            // The message timestamp represents the first instance when the data
+            // was received by PolySync
+            canFrame.setTimestamp( _channel.getInputFrameHardwareTimestamp() );
+
+            // Output CAN frame data.
+            std::cout << "CAN frame - ID: 0x"
+                      << _channel.getInputFrameId()
+                      << std::endl;
+
+            std::cout << "DLC: "
+                      << _channel.getInputFramePayloadSize()
+                      << std::endl << std::endl;
+
+            std::cout << "Data Payload" << std::endl;
+
+            for( auto currentFrame : payloadVector )
+            {
+                std::cout << "\t" << (short) currentFrame << std::endl;
+            }
+
+            // The header timestamp represents when this message was
+            // published to the bus by the producer
+            canFrame.setHeaderTimestamp( polysync::getTimestamp() );
+
+            canFrame.publish();
+        }
+        catch( polysync::DTCException & exception )
+        {
+            auto errorCode = exception.getDtc();
+
+            if( exception.getDtc() != DTC_UNAVAILABLE )
+            {
+                if( errorCode == DTC_INTR )
+                {
+                    std::cout << "CAN read was interrupted, application most "
+                              << "likely received SIGINT (ctrl-c)."
+                              << std::endl;
+
+                    disconnectPolySync();
+
+                    return;
+                }
+
+                std::cout << exception.what() << std::endl;
+
+                // Activate a fault state for this node. The NODE_STATE_ERROR
+                // will trigger call to errorStateEvent.
+                activateFault( exception.getDtc(), NODE_STATE_ERROR );
+            }
+            else
+            {
+                std::cout << "Device unavailable. " << std::endl;
+            }
+        }
+
+        // Sleep for one millisecond
+        polysync::sleepMicro( 1000 );
+    }
+
+    /**
+     * If exceptions occurred in @ref okStateEvent or @ref initStateEvent, we
+     * disconnect, which triggers @ref releaseStateEvent and allows for graceful
+     * exit.
+     */
+    virtual void errorStateEvent()
+    {
+        std::cout << "CANReaderNode::errorStateEvent()" << std::endl;
+
+        disconnectPolySync();
+    }
+
+
+private:
+
+    polysync::CANChannel _channel;
+
+    uint _flags{ PSYNC_CAN_OPEN_ALLOW_VIRTUAL };
+
+    ps_datarate_kind _bitRate{ DATARATE_500K };
+
+};
+
+/**
+ * Entry point for this example application
+ * The "connectPolySync" function begins the node's PolySync execution loop.
+ *
+ * @param argc - int, the number of parameters on the command-line
+ * @param argv - char* [], the parsed command-line arguments
+ *
+ * @return int - exit code
+ */
+int main( int argc, char *argv[] )
+{
+    // Check for shared memory key argument
+    if( argc > 1 )
+    {
+        try
+        {
+            if( polysync::getChannelCount() > 0 )
+            {
+                CANReaderAndPublisher canReader( std::stoul( argv[ 1 ] ) );
+
+                canReader.setNodeName( "polysync-can-reader-cpp" );
+
+                canReader.connectPolySync();
+            }
+            else
+            {
+                std::cout << "No available CAN channels." << std::endl;
+            }
+        }
+        catch( std::exception & e )
+        {
+            std::cout << "Invalid argument. This example requires valid "
+                         "integer input representing a CAN channel."
+                      << std::endl
+                      << "For example: "
+                         "polysync-can-reader-cpp 1"
+                      << std::endl;
+
+            return 1;
+        }
+    }
+    else
+    {
+        std::cout << "Must pass CAN channel argument." << std::endl
+                  << "For example: "
+                     "polysync-can-reader-cpp 1" << std::endl;
+
+        return 1;
+    }
+
+    return 0;
+}

--- a/CANReaderAndPublisher/CMakeLists.txt
+++ b/CANReaderAndPublisher/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required( VERSION 2.8 )
+
+project( polysync-can-reader-and-publisher-cpp )
+
+if( NOT PSYNC_HOME )
+    if( $ENV{PSYNC_HOME} )
+        set( PSYNC_HOME $ENV{PSYNC_HOME} )
+    else()
+        set( PSYNC_HOME /usr/local/polysync )
+    endif()
+endif()
+
+include( ${PSYNC_HOME}/BuildResources.cmake )
+
+include_directories(
+    ${PSYNC_INCLUDE_DIRS}
+)
+
+add_executable(
+    ${PROJECT_NAME}
+    CANReaderAndPublisher.cpp
+)
+
+target_link_libraries( ${PROJECT_NAME}
+    ${PSYNC_LIBS}
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION ${PSYNC_HOME}/bin
+)

--- a/CANReaderAndPublisher/CMakeLists.txt.user
+++ b/CANReaderAndPublisher/CMakeLists.txt.user
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorProject>
+<!-- Written by QtCreator 3.0.1, 2016-09-13T10:25:49. -->
+<qtcreator>
+ <data>
+  <variable>ProjectExplorer.Project.ActiveTarget</variable>
+  <value type="int">0</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.EditorSettings</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
+   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
+   <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
+    <value type="QString" key="language">Cpp</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">CppGlobal</value>
+    </valuemap>
+   </valuemap>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.1">
+    <value type="QString" key="language">QmlJS</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
+    </valuemap>
+   </valuemap>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
+   <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
+   <value type="int" key="EditorConfiguration.IndentSize">4</value>
+   <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
+   <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
+   <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
+   <value type="int" key="EditorConfiguration.TabSize">8</value>
+   <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
+   <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
+   <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
+   <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap"/>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Target.0</variable>
+  <valuemap type="QVariantMap">
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{3a853eac-0594-4aac-a42a-f6744a23af3e}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
+    <value type="bool" key="CMakeProjectManager.CMakeBuildConfiguration.UseNinja">false</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/lj/build-CANReaderAndPublisher-Desktop-Default</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments"></value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets"/>
+      <value type="bool" key="CMakeProjectManager.MakeStep.Clean">false</value>
+      <value type="bool" key="CMakeProjectManager.MakeStep.UseNinja">false</value>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="QString" key="CMakeProjectManager.MakeStep.AdditionalArguments">clean</value>
+      <valuelist type="QVariantList" key="CMakeProjectManager.MakeStep.BuildTargets"/>
+      <value type="bool" key="CMakeProjectManager.MakeStep.Clean">true</value>
+      <value type="bool" key="CMakeProjectManager.MakeStep.UseNinja">false</value>
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.MakeStep</value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Default</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Default</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeBuildConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy locally</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.PluginSettings"/>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguation.Title">polysync-can-reader-and-publisher-cpp</value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.Arguments"></value>
+    <value type="bool" key="CMakeProjectManager.CMakeRunConfiguration.UseTerminal">false</value>
+    <value type="QString" key="CMakeProjectManager.CMakeRunConfiguration.UserWorkingDirectory"></value>
+    <value type="int" key="PE.EnvironmentAspect.Base">2</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">polysync-can-reader-and-publisher-cpp</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">CMakeProjectManager.CMakeRunConfiguration.polysync-can-reader-and-publisher-cpp</value>
+    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">true</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">false</value>
+    <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.TargetCount</variable>
+  <value type="int">1</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.EnvironmentId</variable>
+  <value type="QByteArray">{eb193275-c2f4-44ab-a14e-8793d451fbfd}</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
+  <value type="int">15</value>
+ </data>
+</qtcreator>

--- a/CANReaderAndPublisher/README.md
+++ b/CANReaderAndPublisher/README.md
@@ -1,0 +1,3 @@
+This example demonstrates connecting to a CAN device and reading data.
+
+For more API examples and tutorials, visit the PolySync Knowledgebase [here](https://support.harbrick.com/hc/en-us/articles/216968458)


### PR DESCRIPTION
This is an extension of CANReader.

This will read CAN data using the C++ CAN API, and populuate an instance
of the `ps_can_frame_msg` and publish it to the bus.

This was requested by a customer, and also allows for raw CAN data to be
viewable in Trace plugin.
