### PR TITLE
Fix explicit settings of PSYNC_HOME

### DIFF
--- a/ParameterGetSet/CMakeLists.txt
+++ b/ParameterGetSet/CMakeLists.txt
@@ -10,9 +10,13 @@ add_definitions(
     -std=c++11
     )
 
-set( PSYNC_HOME
-    /usr/local/polysync
-    )
+if( NOT PSYNC_HOME )
+    if( $ENV{PSYNC_HOME} )
+        set( PSYNC_HOME $ENV{PSYNC_HOME} )
+    else()
+        set( PSYNC_HOME /usr/local/polysync )
+    endif()
+endif()
 
 include_directories(
     ${PSYNC_HOME}/include


### PR DESCRIPTION
Prior to this commit, the CMakeLists.txt of the ParameterGetSet example
explicitly set PSYNC_HOME to /usr/local/polysync instead of checking for
an environment variable first, which caused errors if a user's machine
had PSYNC_HOME elsewhere. This commit first checks for an environment
variable before setting it explicitly.