### PR TITLE
Add the CSV export node example

### DIFF
--- a/CSVExporter/CMakeLists.txt
+++ b/CSVExporter/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required( VERSION 2.8 )
+
+project( polysync-csv-export )
+
+if( NOT PSYNC_HOME )
+    if( $ENV{PSYNC_HOME} )
+        set( PSYNC_HOME $ENV{PSYNC_HOME} )
+    else()
+        set( PSYNC_HOME /usr/local/polysync )
+    endif()
+endif()
+
+include( ${PSYNC_HOME}/BuildResources.cmake )
+
+include_directories(
+    include
+    ${PSYNC_INCLUDE_DIRS}
+)
+
+add_executable( ${PROJECT_NAME}
+    CSVExport.cpp
+    SubscriberMap.cpp
+    Subscriber.cpp
+)
+
+target_link_libraries( ${PROJECT_NAME}
+    getopt_cpp 
+    ${PSYNC_LIBS}
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION ${PSYNC_HOME}/bin
+)

--- a/CSVExporter/CSVExport.cpp
+++ b/CSVExporter/CSVExport.cpp
@@ -1,0 +1,133 @@
+#include "CSVExport.hpp"
+
+/**
+ * @brief This function is main which collects arguments passed in and then
+ * proceeds to open a subscriber application. Each subscriber is a templated
+ * class with in the SubscriberMap factory constructing one CSV for each
+ * message topic. The csv files are names by message type name and a common
+ * timestamp at subscriber spin up.
+ */
+int main( int argc, char *argv[] )
+{
+    //Load in the Subscriber Factory that builds message types from args
+    SubscriberMap callType;
+
+    Parameters setParameters;
+    
+    //Set the arguments passed in from command line and error out if empty
+    //or missing atleast one message type
+    if( handleOptions( 
+            {argc, argv}, 
+            &setParameters ) != 0 )
+    {
+        return 1;
+    }
+
+    if( setParameters.messageType.empty() )
+    {
+        printMissingMessageType();
+
+        return 0;
+    }
+
+    //Subscribe to each message type requested by the user
+    std::vector< std::string >::iterator messageTypeIterator;
+    std::vector< polysync::DataSubscriber* > subscriberType;
+
+    for( messageTypeIterator = setParameters.messageType.begin();
+            messageTypeIterator != setParameters.messageType.end();
+            messageTypeIterator++ )
+    {
+        subscriberType.push_back(callType.newType( 
+                    *messageTypeIterator ) );
+    }
+
+    //Now that all subscribers are up connect with the polysync bus
+    polysync::Application::getInstance()->connectPolySync();
+
+    //Once connection has been left cleanup subscriber classes
+    std::vector< polysync::DataSubscriber* >::iterator subscriberIterator; 
+
+    for( subscriberIterator = subscriberType.begin();
+            subscriberIterator != subscriberType.end();
+            subscriberIterator++ )
+    {
+        delete *subscriberIterator;
+    }
+
+    return 0;
+}
+
+
+int handleOptions( 
+        GetOpt && getOpt, 
+        Parameters * setParameters )
+{
+    if( getOpt.getOptions().empty() )
+    {
+        std::cout << "It appears you have not entered any arguments ";
+        
+        std::cout << "showing help:\n";
+        
+        printHelp();
+        
+        return 1;
+    }
+
+    for ( auto option : getOpt.getOptions() )
+    {
+        //Check for message type as this is required
+        if( option.getOptionString() == "t" )
+        {
+            setParameters->messageType = option.getArguments();
+        }
+        
+        if( option.getOptionString() == "h" )
+        {
+            printHelp();
+            
+            return 1;
+        }
+
+        if( option.getOptionString() == "m" )
+        {
+            SubscriberMap messages;
+            messages.printMessages();
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+void printHelp()
+{
+    std::cout << "Message Type is a required option all others are optional\n";
+    
+    std::cout << "Options: \n";
+    
+    std::cout << "Flag:     Description:                Default:\n";
+    
+    std::cout << "-t        Message Type\n"; 
+    
+    std::cout << "-m        Print available messages\n";
+
+    std::cout << "-h        Prints help\n";
+
+    return;
+}
+
+
+void printMissingMessageType()
+{
+    std::cout << "It appears a Message Type was not set, ";
+    
+    std::cout << "make sure to set one or more message type(s) with -t.\n";
+        
+    SubscriberMap messages;
+    messages.printMessages(); 
+
+    return;
+}
+

--- a/CSVExporter/Subscriber.cpp
+++ b/CSVExporter/Subscriber.cpp
@@ -1,0 +1,460 @@
+#include "Subscriber.hpp"
+
+template<>
+void Subscriber<polysync::datamodel::RadarTargetsMessage>::handleEvents( 
+        std::shared_ptr<polysync::Message> message )
+{
+    if( auto inMessage = polysync::datamodel::getSubclass< 
+            polysync::datamodel::RadarTargetsMessage >( message ) )
+    {
+        std::stringstream repeatStream;
+
+        outputHeaderData( repeatStream, inMessage );
+
+        //Wrap all output around Targets/Objects so header and sensor descriptor
+        //data repeats
+        auto outputTargets = inMessage->getTargets();
+        
+        std::vector< polysync::datamodel::RadarTarget >::iterator 
+            outputTargetsIterator;
+      
+
+        for( outputTargetsIterator = outputTargets.begin();
+                outputTargetsIterator != outputTargets.end();
+                outputTargetsIterator++ )
+        {
+            auto outputPositions = outputTargetsIterator->getPosition();
+            auto outputSize = outputTargetsIterator->getSize();
+            auto outputVelocity = outputTargetsIterator->getVelocity();
+
+            _outFile 
+                << repeatStream.str()
+                << outputTargetsIterator->getId() << ","
+                << outputTargetsIterator->getTimestamp() << ","
+                << ( uint ) outputTargetsIterator->getNativeTimestampFormat() << ","
+                << outputTargetsIterator->getNativeTimestampValue() << ","
+                << outputPositions[ 0 ] << ","
+                << outputPositions[ 1 ] << ","
+                << outputPositions[ 2 ] << ","
+                << outputSize[ 0 ] << ","
+                << outputSize[ 1 ] << ","
+                << outputSize[ 2 ] << ","
+                << outputVelocity[ 0 ] << ","
+                << outputVelocity[ 1 ] << ","
+                << outputVelocity[ 2 ] << ","
+                << outputTargetsIterator->getRangeRate() << ","
+                << outputTargetsIterator->getTrackStatus() << ","
+                << outputTargetsIterator->getRangeType() << ","
+                << outputTargetsIterator->getZoneType() << ","
+                << outputTargetsIterator->getQuality() << ","
+                << outputTargetsIterator->getAmplitude() << ","
+                << outputTargetsIterator->getMagnitude() << ","
+                << outputTargetsIterator->getAlias() << ","
+                << outputTargetsIterator->getCrossSection() << ","
+                << outputTargetsIterator->getScanIndex() << "\n";
+        }
+    }
+
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::RadarTargetsMessage >::outputCSVHeader()
+{
+    _outFile << "HeaderType" << ","
+        << "HeaderTimestamp" << ","
+        << "HeaderSrcGuid" << ","
+        << "SensorDescriptorId" << ","
+        << "SensorDescriptorType" << ","
+        << "SensorDescriptorTransformParentId" << ","
+        << "SensorDescriptorTransformTimestamp" << ","
+        << "SensorDescriptorTransformStack0Id" << ","
+        << "SensorDescriptorTransformStack0Timestamp" << ","
+        << "SensorDescriptorTransformStack0Origin0" << ","
+        << "SensorDescriptorTransformStack0Origin1" << ","
+        << "SensorDescriptorTransformStack0Origin2" << ","
+        << "SensorDescriptorTransformStack0Orientation0" << ","
+        << "SensorDescriptorTransformStack0Orientation1" << ","
+        << "SensorDescriptorTransformStack0Orientation2" << ","
+        << "SensorDescriptorTransformStack0Orientation3" << ","
+        << "RadarTargetId" << ","
+        << "RadarTargetTimestamp" << ","
+        << "RadarTargetNativeTimestampFormat" << ","
+        << "RadarTargetNativeTimestampValue" << ","
+        << "RadarTargetPosition0" << ","
+        << "RadarTargetPosition1" << ","
+        << "RadarTargetPosition2" << ","
+        << "RadarTargetSize0" << ","
+        << "RadarTargetSize1" << ","
+        << "RadarTargetSize2" << ","
+        << "RadarTargetVelocity0" << ","
+        << "RadarTargetVelocity1" << ","
+        << "RadarTargetVelocity2" << ","
+        << "RadarTargetRangeRate" << ","
+        << "RadarTargetTrackStatus" << ","
+        << "RadarTargetRangeType" << ","
+        << "RadarTargetZoneType" << ","
+        << "RadarTargetQuality" << ","
+        << "RadarTargetAmplitude" << ","
+        << "RadarTargetMagnitude" << ","
+        << "RadarTargetAlias" << ","
+        << "RadarTargetCrossSection" << ","
+        << "RadarTargetScanIndex" << "\n";
+    
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::LidarPointsMessage >::handleEvents( 
+        std::shared_ptr<polysync::Message> message )
+{
+    if( auto inMessage = 
+            polysync::datamodel::getSubclass< 
+                polysync::datamodel::LidarPointsMessage >( message ) )
+    {
+        std::stringstream repeatStream;
+
+        outputHeaderData( repeatStream, inMessage );
+        
+        repeatStream 
+            << inMessage->getStartTimestamp() << ","
+            << inMessage->getEndTimestamp() << ","
+            << ( uint ) inMessage->getNativeStartTimestampFormat() << ","
+            << inMessage->getNativeStartTimestampValue() << ",";
+
+        //Wrap all output around Targets/Objects so header and sensor descriptor 
+        //data repeats
+        auto outputPoints = inMessage->getPoints();
+        
+        std::vector<polysync::datamodel::LidarPoint>::iterator 
+            outputPointsIterator;
+      
+
+        for( outputPointsIterator = outputPoints.begin();
+                outputPointsIterator != outputPoints.end();
+                outputPointsIterator++ )
+        {
+            auto position = outputPointsIterator->getPosition();
+            
+            //Output each target
+            if( _outFile.good() )
+            {
+                _outFile 
+                    << repeatStream.str()
+                    << position[ 0 ] << ","
+                    << position[ 1 ] << ","
+                    << position[ 2 ] << ","
+                    << ( uint ) outputPointsIterator->getIntensity()
+                    << "\n";
+            }
+            else
+            {
+                std::cout << "Error writing to file stream..." << std::endl;
+            }    
+        }
+    }
+
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::LidarPointsMessage >::outputCSVHeader()
+{
+    _outFile << "HeaderType" << ","
+        << "HeaderTimestamp" << ","
+        << "HeaderSrcGuid" << ","
+        << "SensorDescriptorId" << ","
+        << "SensorDescriptorType" << ","
+        << "SensorDescriptorTransformParentId" << ","
+        << "SensorDescriptorTransformTimestamp" << ","
+        << "SensorDescriptorTransformStack0Id" << ","
+        << "SensorDescriptorTransformStack0Timestamp" << ","
+        << "SensorDescriptorTransformStack0Origin0" << ","
+        << "SensorDescriptorTransformStack0Origin1" << ","
+        << "SensorDescriptorTransformStack0Origin2" << ","
+        << "SensorDescriptorTransformStack0Orientation0" << ","
+        << "SensorDescriptorTransformStack0Orientation1" << ","
+        << "SensorDescriptorTransformStack0Orientation2" << ","
+        << "SensorDescriptorTransformStack0Orientation3" << ","
+        << "StartTimestamp" << "," 
+        << "EndTimestamp" << ","
+        << "NativeStartTimestampFormat" << ","
+        << "NativeStartTimestampValue" << ","
+        << "PointsPosition0" << ","
+        << "PointsPosition1" << ","
+        << "PointsPosition2" << ","
+        << "PointsIntensity" << "\n";
+
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::LaneModelMessage >::handleEvents( 
+        std::shared_ptr<polysync::Message> message )
+{
+    if( auto inMessage = 
+            polysync::datamodel::getSubclass< 
+                polysync::datamodel::LaneModelMessage >( message ) )
+    {
+        std::stringstream repeatStream;
+
+        outputHeaderData( repeatStream, inMessage );
+ 
+        //Wrap all output around Lanes so header and sensor descriptor 
+        //data repeats
+        auto outputLanes = inMessage->getLanes();
+        
+        std::vector<polysync::datamodel::LaneModel>::iterator 
+            outputLanesIterator;
+      
+        for( outputLanesIterator = outputLanes.begin();
+                outputLanesIterator != outputLanes.end();
+                outputLanesIterator++ )
+        {
+            _outFile 
+                << repeatStream.str()
+                << outputLanesIterator->getTimestamp() << ","
+                << ( uint ) outputLanesIterator->getNativeTimestampFormat() << ","
+                << outputLanesIterator->getNativeTimestampValue() << ","
+                << outputLanesIterator->getQuality() << ","
+                << outputLanesIterator->getMarkerType() << ","
+                << outputLanesIterator->getModelType() << ","
+                << outputLanesIterator->getMarkerWidth() << ","
+                << outputLanesIterator->getHeadingAngle() << ","
+                << outputLanesIterator->getViewRange() << ","
+                << outputLanesIterator->getMarkerOffset() << ","
+                << outputLanesIterator->getCurvature() << ","
+                << outputLanesIterator->getCurvatureDerivative() 
+                << ","
+                << outputLanesIterator->getTimeToCrossing() << "\n";
+        }
+    }
+
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::LaneModelMessage >::outputCSVHeader()
+{
+    _outFile << "HeaderType" << ","
+        << "HeaderTimestamp" << ","
+        << "HeaderSrcGuid" << ","
+        << "SensorDescriptorId" << ","
+        << "SensorDescriptorType" << ","
+        << "SensorDescriptorTransformParentId" << ","
+        << "SensorDescriptorTransformTimestamp" << ","
+        << "SensorDescriptorTransformStack0Id" << ","
+        << "SensorDescriptorTransformStack0Timestamp" << ","
+        << "SensorDescriptorTransformStack0Origin0" << ","
+        << "SensorDescriptorTransformStack0Origin1" << ","
+        << "SensorDescriptorTransformStack0Origin2" << ","
+        << "SensorDescriptorTransformStack0Orientation0" << ","
+        << "SensorDescriptorTransformStack0Orientation1" << ","
+        << "SensorDescriptorTransformStack0Orientation2" << ","
+        << "SensorDescriptorTransformStack0Orientation3" << ","
+        << "LanesTimestamp" << ","
+        << "LanesNativeTimestampFormat" << ","
+        << "LanesNativeTimestampValue" << ","
+        << "LanesQuality" << ","
+        << "LanesMarkerType" << ","
+        << "LanesModelType" << ","
+        << "LanesMarkerWidth" << ","
+        << "LanesHeadingAngle" << ","
+        << "LanesViewRange" << ","
+        << "LanesMarkerOffset" << ","
+        << "LanesCurvature" << ","
+        << "LanesCurvatureDerivative" << ","
+        << "LanesTimeToCrossing" << "\n";
+
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::ObjectsMessage >::handleEvents( 
+        std::shared_ptr<polysync::Message> message )
+{
+    
+    if( auto inMessage = 
+            polysync::datamodel::getSubclass< 
+                polysync::datamodel::ObjectsMessage >( message ) )
+    {
+        std::stringstream repeatStream;
+
+        outputHeaderData( repeatStream, inMessage );
+
+        //Wrap all output around Objects so header and sensor descriptor 
+        //data repeats
+        auto outputObjects = inMessage->getObjects();
+        
+        std::vector<polysync::datamodel::Object>::iterator 
+            outputObjectsIterator;
+      
+        for( outputObjectsIterator = outputObjects.begin();
+                outputObjectsIterator != outputObjects.end();
+                outputObjectsIterator++ )
+        {
+            auto outputPositions = outputObjectsIterator->getPosition();
+            auto outputSize = outputObjectsIterator->getSize();
+            auto outputVelocity  = outputObjectsIterator->getVelocity();
+
+            _outFile 
+                << repeatStream.str()
+                << outputObjectsIterator->getId() << ","
+                << outputObjectsIterator->getTimestamp() << ","
+                << ( uint ) outputObjectsIterator->getNativeTimestampFormat() 
+                << ","
+                << outputObjectsIterator->getNativeTimestampValue() << ","
+                << outputPositions[ 0 ] << ","
+                << outputPositions[ 1 ] << ","
+                << outputPositions[ 2 ] << ","
+                << outputSize[ 0 ] << ","
+                << outputSize[ 1 ] << ","
+                << outputSize[ 2 ] << ","
+                << outputVelocity[ 0 ] << ","
+                << outputVelocity[ 1 ] << ","
+                << outputVelocity[ 2 ] << ","
+                << outputObjectsIterator->getCourseAngle() << ","
+                << outputObjectsIterator->getClassification() << ","
+                << outputObjectsIterator->getClassificationQuality() << "\n";
+        }
+    }
+    
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::ObjectsMessage >::outputCSVHeader()
+{
+    _outFile 
+        << "HeaderType" << ","
+        << "HeaderTimestamp" << ","
+        << "HeaderSrcGuid" << ","
+        << "SensorDescriptorId" << ","
+        << "SensorDescriptorType" << ","
+        << "SensorDescriptorTransformParentId" << ","
+        << "SensorDescriptorTransformTimestamp" << ","
+        << "SensorDescriptorTransformStack0Id" << ","
+        << "SensorDescriptorTransformStack0Timestamp" << ","
+        << "SensorDescriptorTransformStack0Origin0" << ","
+        << "SensorDescriptorTransformStack0Origin1" << ","
+        << "SensorDescriptorTransformStack0Origin2" << ","
+        << "SensorDescriptorTransformStack0Orientation0" << ","
+        << "SensorDescriptorTransformStack0Orientation1" << ","
+        << "SensorDescriptorTransformStack0Orientation2" << ","
+        << "SensorDescriptorTransformStack0Orientation3" << ","
+        << "ObjectsId" << ","
+        << "ObjectsTimestamp" << ","
+        << "ObjectsNativeTimestampFormat" << ","
+        << "ObjectsNativeTimestampValue" << ","
+        << "ObjectsPosition0" << ","
+        << "ObjectsPosition1" << ","
+        << "ObjectsPosition2" << ","
+        << "ObjectsSize0" << ","
+        << "ObjectsSize1" << ","
+        << "ObjectsSize2" << ","
+        << "ObjectsVelocity0" << ","
+        << "ObjectsVelocity1" << ","
+        << "ObjectsVelocity2" << ","
+        << "ObjectsCourseAngle" << ","
+        << "ObjectsClassification" << ","
+        << "ObjectsClassificationQuality" << "\n";
+
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::PlatformMotionMessage >::handleEvents(
+        std::shared_ptr<polysync::Message> message )
+{
+    
+    if( auto inMessage = 
+            polysync::datamodel::getSubclass< 
+                polysync::datamodel::PlatformMotionMessage >( message ) )
+    {
+        std::stringstream repeatStream;
+
+        outputHeaderData( repeatStream, inMessage );
+
+        auto outputPosition = inMessage->getPosition();
+        auto outputOrientation = inMessage->getOrientation();
+        auto outputRotationRate = inMessage->getRotationRate();
+        auto outputVelocity = inMessage->getVelocity();
+        auto outputAcceleration = inMessage->getAcceleration();
+
+        _outFile
+            << repeatStream.str()
+            << inMessage->getTimestamp() << ","
+            << ( uint ) inMessage->getNativeTimestampFormat() << ","
+            << inMessage->getNativeTimestampValue() << ","
+            << outputPosition[ 0 ] << ","
+            << outputPosition[ 1 ] << ","
+            << outputPosition[ 2 ] << ","
+            << outputOrientation[ 0 ] << ","
+            << outputOrientation[ 1 ] << ","
+            << outputOrientation[ 2 ] << ","
+            << outputOrientation[ 3 ] << ","
+            << outputRotationRate[ 0 ] << ","
+            << outputRotationRate[ 1 ] << ","
+            << outputRotationRate[ 2 ] << ","
+            << outputVelocity[ 0 ] << ","
+            << outputVelocity[ 1 ] << ","
+            << outputVelocity[ 2 ] << ","
+            << outputAcceleration[ 0 ] << ","
+            << outputAcceleration[ 1 ] << ","
+            << outputAcceleration[ 2 ] << ","
+            << inMessage->getHeading() << ","
+            << inMessage->getLatitude() << ","
+            << inMessage->getLongitude() << ","
+            << inMessage->getAltitude() << "\n";
+    }
+    
+    return;
+}
+
+template<>
+void Subscriber< polysync::datamodel::PlatformMotionMessage >::outputCSVHeader()
+{
+    _outFile 
+        << "HeaderType" << ","
+        << "HeaderTimestamp" << ","
+        << "HeaderSrcGuid" << ","
+        << "SensorDescriptorId" << ","
+        << "SensorDescriptorType" << ","
+        << "SensorDescriptorTransformParentId" << ","
+        << "SensorDescriptorTransformTimestamp" << ","
+        << "SensorDescriptorTransformStack0Id" << ","
+        << "SensorDescriptorTransformStack0Timestamp" << ","
+        << "SensorDescriptorTransformStack0Origin0" << ","
+        << "SensorDescriptorTransformStack0Origin1" << ","
+        << "SensorDescriptorTransformStack0Origin2" << ","
+        << "SensorDescriptorTransformStack0Orientation0" << ","
+        << "SensorDescriptorTransformStack0Orientation1" << ","
+        << "SensorDescriptorTransformStack0Orientation2" << ","
+        << "SensorDescriptorTransformStack0Orientation3" << ","
+        << "Timestamp" << ","
+        << "NativeTimestampFormat" << ","
+        << "NativeTimestampValue" << ","
+        << "Position0" << ","
+        << "Position1" << ","
+        << "Position2" << ","
+        << "Orientation0" << ","
+        << "Orientation1" << ","
+        << "Orientation2" << ","
+        << "Orientation3" << ","
+        << "RotationRate0" << ","
+        << "RotationRate1" << ","
+        << "RotationRate2" << ","
+        << "Velocity0" << ","
+        << "Velocity1" << ","
+        << "Velocity2" << ","
+        << "Acceleration0" << ","
+        << "Acceleration1" << ","
+        << "Acceleration2" << ","
+        << "Heading" << ","
+        << "Latitude" << ","
+        << "Longitude" << ","
+        << "Altitude" << "\n";
+
+    return;
+}
+

--- a/CSVExporter/SubscriberMap.cpp
+++ b/CSVExporter/SubscriberMap.cpp
@@ -1,0 +1,44 @@
+#include "SubscriberMap.hpp"
+
+//A function to initialize the mapping of all node types
+SubscriberMap::SubscriberMap()
+{
+    _initTimestamp = polysync::getTimestamp();
+
+    _outputMessages[ "ps_radar_targets_msg" ] =
+        Subscriber<
+                polysync::datamodel::RadarTargetsMessage >::Create;    
+    _outputMessages[ "ps_lidar_points_msg" ] =
+        Subscriber<
+                polysync::datamodel::LidarPointsMessage >::Create;
+    _outputMessages[ "ps_lane_model_msg" ] =
+        Subscriber<
+                polysync::datamodel::LaneModelMessage >::Create;
+    _outputMessages[ "ps_objects_msg" ] =
+        Subscriber<
+                polysync::datamodel::ObjectsMessage >::Create;
+    _outputMessages[ "ps_platform_motion_msg"] =
+        Subscriber<
+                polysync::datamodel::PlatformMotionMessage >::Create;
+}
+    
+//Call of actual bridge type spins up a node with any
+//parameters which must be set first
+polysync::DataSubscriber* SubscriberMap::newType( std::string nodeType )
+{
+    return _outputMessages[ nodeType ]( _initTimestamp );
+}
+
+void SubscriberMap::printMessages()
+{
+    std::cout << "Available messages are:\n";
+
+    for(
+            _messagesIterator = _outputMessages.begin();
+            _messagesIterator != _outputMessages.end();
+            _messagesIterator++ )
+    {
+        std::cout << _messagesIterator->first << "\n";
+    }
+
+}

--- a/CSVExporter/include/CSVExport.hpp
+++ b/CSVExporter/include/CSVExport.hpp
@@ -1,0 +1,54 @@
+#ifndef CSVEXPORT_HPP
+#define CSVEXPORT_HPP
+
+#include <ostream> /* std */
+#include <thread>
+#include <vector>
+#include <algorithm>
+#include <cassert>
+
+#include <PolySyncNode.hpp> /* PolySync files */
+#include <PolySyncDataModel.hpp>
+#include <GetOpt.hpp>
+
+#include "SubscriberMap.hpp" /* Local files */
+
+/**
+ *class Parameters
+ * This class is used to pass parameters around for command line arguments.
+ */
+class Parameters
+{
+public:
+    
+    std::vector<std::string> messageType;
+};
+
+/**
+ * @brief This function is to take in command line arguments and handle them.
+ * Arguments go to two locations, the Parameters class used in main and
+ * directly set in the TypeMap which is used through out main.
+ * 
+ * @param getOpt [in] command line arguments from the GetOpt library.
+ * 
+ * @param setType [out] the TypeMap where it's parameters are set.
+ * 
+ * @param setParameters [out] the Parameters class used for main parameters.
+ */
+int handleOptions( 
+        GetOpt && getOpt, 
+        Parameters * setParameters );
+
+/**
+ * @brief This function prints out the command line options.
+ */
+void printHelp();
+
+/**
+ * @brief This function prints out an error message for when the Message type 
+ * has not been passed in as an argument.
+ */
+void printMissingMessageType();
+
+#endif // CSVEXPORT_HPP
+

--- a/CSVExporter/include/Subscriber.hpp
+++ b/CSVExporter/include/Subscriber.hpp
@@ -1,0 +1,141 @@
+#ifndef SUBSCRIBER_HPP
+#define SUBSCRIBER_HPP
+
+#include <fstream> /* std */
+#include <iostream>
+#include <sstream>
+
+#include <PolySyncDataModel.hpp> /* PolySync files */
+#include <PolySyncDataSubscriber.hpp>
+#include <PolySyncApplication.hpp>
+
+
+template < typename psType > class Subscriber : 
+    public polysync::DataSubscriber
+{
+   
+public:
+    /**
+     * @brief This function creates an instance of the class with a specific
+     * node type provided and returns the base class pointer.
+     * 
+     * @return The base pointer of this class.
+     */
+    static DataSubscriber * Create( unsigned long int timestamp ) 
+    {
+        return new Subscriber< psType >( timestamp );
+    }
+
+    /**
+     * @brief This is the class construction where the timestamp is syncronized
+     * in order to provide the same timestamp in each file name created. A new
+     * file is opened with the name of the message type and the timestamp passed
+     * in with this function.
+     *
+     * @param [in] A polysync timestamp value in order to append the same time
+     * to each export file of different message types.
+     */
+    Subscriber ( unsigned long int timestamp )
+    {
+        _initTimestamp = timestamp;
+
+        //Connect the Subscriber
+        connectSubscriberMethod< Subscriber >(
+                psType::getName(),
+                &Subscriber::handleEvents,
+                this );
+
+        polysync::Application::getInstance()->attachSubscriber( this );
+
+        //Initialize a CSV with column header dump
+        std::string filename = 
+            psType::getName() + 
+            "_" + 
+            std::to_string( _initTimestamp ) + 
+            ".csv";
+
+        _outFile.open( filename, std::ios::app | std::ios::binary );
+        
+        _outFile << std::fixed;
+
+        outputCSVHeader();
+    }
+
+    /**
+     *@brief This function cleanly closes the CSV file and deletes the stream.
+     */
+    ~Subscriber()
+    {
+        _outFile.close();
+    }
+
+
+private:
+   
+    std::ofstream _outFile;
+    
+    unsigned long int _initTimestamp;
+
+    /**
+     * @brief This function is the handler for incoming messages. Where the
+     * message data will be output to a CSV file stream.
+     * 
+     * @param [in] the message to be converted to CSV.
+     */
+    void handleEvents( std::shared_ptr< polysync::Message > message );
+
+    /**
+     * @brief This function outputs the CSV column header information to the
+     * file stream after it has been opened.
+     */
+    void outputCSVHeader();
+ 
+    /**
+     * @brief This function is a general output of the header and
+     * sensor_descriptor information.
+     *
+     * @param [out] The stream to output this data.
+     */
+    void outputHeaderData( 
+            std::stringstream & repeatStream, 
+            std::shared_ptr< psType > output )
+    {
+        //Construct repeating row information
+        repeatStream 
+            << output->getHeaderType() << ","
+            << output->getHeaderTimestamp() << ","
+            << output->getHeaderSrcGuid() << ","
+            << output->getSensorDescriptorId() << ","
+            << output->getSensorDescriptorType() << ","
+            << output->getSensorDescriptorTransformParentId() << ","
+            << output->getSensorDescriptorTransformTimestamp() << ",";
+
+        auto stack = output->getSensorDescriptorTransformStack();
+
+        if( stack.size() > 0 )
+        {
+            auto origin = stack.front().getOrigin();
+            auto orientation = stack.front().getOrientation();
+
+            repeatStream
+                << stack.front().getId() << ","
+                << stack.front().getTimestamp() << ","
+                << origin[ 0 ] << ","
+                << origin[ 1 ] << ","
+                << origin[ 2 ] << ","
+                << orientation[ 0 ] << ","
+                << orientation[ 1 ] << ","
+                << orientation[ 2 ] << ","
+                << orientation[ 3 ] << ",";
+        }
+        else
+        {
+            repeatStream << ",,,,,,,,,";
+        }
+        
+        return;
+    }
+
+}; //End Class
+
+#endif // SUBSCRIBER_HPP

--- a/CSVExporter/include/SubscriberMap.hpp
+++ b/CSVExporter/include/SubscriberMap.hpp
@@ -1,0 +1,62 @@
+#ifndef SUBSCRIBERMAP_HPP
+#define SUBSCRIBERMAP_HPP
+
+#include <functional> /* std */
+#include <map>
+
+#include "Subscriber.hpp" /* PolySync */
+
+/**
+ * @class SubscriberMap
+ * This class is used to map from string to a message type allowing for command
+ * line arguments. This map uses a template class Subscriber.hpp to
+ * construct each message type and a Create function which returns the base 
+ * pointer [DataSubscriber].
+ * 
+ * @code
+ * 
+ * SubscriberMap callType;
+ * 
+ * auto myMessageType = callType.newType( "ps_radar_targets_msg" );
+ *
+ * polysync::Application::getInstance()->connectPolySync();
+ * 
+ * delete myMessageType;
+ * 
+ * @endcode
+ */
+class SubscriberMap 
+{ 
+
+public:
+    SubscriberMap();
+
+    /**
+     * @brief This function initializes a node of a specific type from the
+     * template class.
+     * 
+     * @param bridgeType [in] the c type name of message to be constructed
+     * 
+     * @return The base class pointer of polysync::Node*
+     */
+    polysync::DataSubscriber* newType(std::string nodeType);
+
+    /**
+     * @brief This function prints out the available messages in the map for
+     * use with the help output in the arguments.
+     */
+    void printMessages();
+
+private: 
+    
+    //The primary map used for calling various node types by string name
+    std::map< std::string, std::function< polysync::DataSubscriber*(
+            unsigned long int timestamp ) > > _outputMessages;
+    std::map< std::string, std::function< polysync::DataSubscriber*(
+            unsigned long int timestamp ) > >::iterator _messagesIterator;
+    
+    unsigned long int _initTimestamp;
+
+};
+
+#endif //SUBSCRIBERMAP_HPP


### PR DESCRIPTION
This tool is part of the PolySync-MATLAB/Simulink BETA feature, but can be used to export data from an active PolySync runtime, to CSV.

This commit adds the resources to be able to export the following message types to CSV files.

- `ps_lane_model_msg`
- `ps_lidar_points_msg`
- `ps_objects_msg`
- `ps_platform_motion_msg`
- `ps_radar_targets_msg`
- `ps_traffic_sign_msg`