### PR TITLE
Fix compile error.

### DIFF
--- a/PathPlanner/include/Planner.hpp
+++ b/PathPlanner/include/Planner.hpp
@@ -4,9 +4,6 @@
 #include "GridMap.hpp"
 
 
-using namespace std;
-
-
 class Planner
 {
 

--- a/PathPlanner/src/Planner.cpp
+++ b/PathPlanner/src/Planner.cpp
@@ -25,6 +25,8 @@
 
 #include <cmath>
 #include <iostream>
+#include <array>
+
 
 #include "Planner.hpp"
 


### PR DESCRIPTION
Prior to this commit the path planning example was missing include required to
use std::array. After this commit that include is present.