### PR TITLE
Add README.md files to c++ examples

### DIFF
--- a/CANReader/README.md
+++ b/CANReader/README.md
@@ -6,6 +6,7 @@ This example will give you experience for the times you need a node to listen to
 - linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
 
 ### Dependencies
+You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
 ### Building and Running the Node
 ```bash
@@ -13,7 +14,6 @@ $ cd CANReader
 $ mkdir build && cd build
 $ cmake ..
 $ make
-# You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 $ ./polysync-can-reader-cpp 1
 ```
 

--- a/CANReader/README.md
+++ b/CANReader/README.md
@@ -1,14 +1,26 @@
 ### CANReader
+
 Using the PolySync state machine this example does a simple CAN read in OK the state.
 This example will give you experience for the times you need a node to listen to a CAN channel.
 
 ### Hardware requirements
+
 - linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
 
 ### Dependencies
+
 You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd CANReader 
 $ mkdir build && cd build

--- a/CANReader/README.md
+++ b/CANReader/README.md
@@ -1,3 +1,20 @@
-This example demonstrates connecting to a CAN device and reading data.
+### CANReader
+Using the PolySync state machine this example does a simple CAN read in OK the state.
+This example will give you experience for the times you need a node to listen to a CAN channel.
 
-For more API examples and tutorials, visit the PolySync Knowledgebase [here](https://support.harbrick.com/hc/en-us/articles/216968458)
+### Hardware requirements
+- linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd CANReader 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+# You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
+$ ./polysync-can-reader-cpp 1
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/CANReader/README.md
+++ b/CANReader/README.md
@@ -1,7 +1,7 @@
 ### CANReader
 
-Using the PolySync state machine this example does a simple CAN read in OK the state.
-This example will give you experience for the times you need a node to listen to a CAN channel.
+Using the PolySync state machine, this example does a simple CAN read in the OK state.
+This example also acts as a guide for when you need a node to listen to a CAN channel.
 
 ### Hardware requirements
 
@@ -9,7 +9,7 @@ This example will give you experience for the times you need a node to listen to
 
 ### Dependencies
 
-You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
+You need to have a CAN channel to run this example, see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
 Packages: libglib2.0-dev
 
@@ -19,7 +19,7 @@ To install on Ubuntu
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd CANReader 
@@ -29,4 +29,4 @@ $ make
 $ ./polysync-can-reader-cpp 1
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/CANReaderAndPublisher/README.md
+++ b/CANReaderAndPublisher/README.md
@@ -1,14 +1,26 @@
 ### CANReaderAndPublisher
+
 This example will give you experience for the times you need a node to read and publish data on a CAN channel.
 Using the PolySync state machine this example does a simple CAN read and publishes each CAN frame received to the PolySync bus as a `ps_can_frame_msg`.
 
 ### Hardware requirements
+
 - linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
 
 ### Dependencies
+
 You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd CANReaderAndPublisher 
 $ mkdir build && cd build
@@ -16,4 +28,5 @@ $ cmake ..
 $ make
 $ ./polysync-can-reader-and-publisher-cpp 1
 ```
+
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/CANReaderAndPublisher/README.md
+++ b/CANReaderAndPublisher/README.md
@@ -1,3 +1,20 @@
-This example demonstrates connecting to a CAN device and reading data.
+Using the PolySync state machine this example does a simple CAN read in OK the state.
 
-For more API examples and tutorials, visit the PolySync Knowledgebase [here](https://support.harbrick.com/hc/en-us/articles/216968458)
+PolySync knowlege gained:
+This example will give you experience for the times you need a node to listen and publish data to a CAN channel.
+
+### Hardware requirements
+- linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd CANReaderAndPublisher 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+# You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
+$ ./polysync-can-reader-and-publisher-cpp 1
+```
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/CANReaderAndPublisher/README.md
+++ b/CANReaderAndPublisher/README.md
@@ -1,12 +1,12 @@
-Using the PolySync state machine this example does a simple CAN read in OK the state.
-
-PolySync knowlege gained:
-This example will give you experience for the times you need a node to listen and publish data to a CAN channel.
+### CANReaderAndPublisher
+This example will give you experience for the times you need a node to read and publish data on a CAN channel.
+Using the PolySync state machine this example does a simple CAN read and publishes each CAN frame received to the PolySync bus as a `ps_can_frame_msg`.
 
 ### Hardware requirements
 - linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
 
 ### Dependencies
+You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
 ### Building and Running the Node
 ```bash
@@ -14,7 +14,6 @@ $ cd CANReaderAndPublisher
 $ mkdir build && cd build
 $ cmake ..
 $ make
-# You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 $ ./polysync-can-reader-and-publisher-cpp 1
 ```
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/CANReaderAndPublisher/README.md
+++ b/CANReaderAndPublisher/README.md
@@ -1,7 +1,7 @@
 ### CANReaderAndPublisher
 
-This example will give you experience for the times you need a node to read and publish data on a CAN channel.
-Using the PolySync state machine this example does a simple CAN read and publishes each CAN frame received to the PolySync bus as a `ps_can_frame_msg`.
+This example also acts as a guide for when you need a node to read and publish data on a CAN channel.
+Using the PolySync state machine, this example does a simple CAN read and publishes each CAN frame received to the PolySync bus as a `ps_can_frame_msg`.
 
 ### Hardware requirements
 
@@ -9,7 +9,7 @@ Using the PolySync state machine this example does a simple CAN read and publish
 
 ### Dependencies
 
-You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
+You need to have a CAN channel to run this example, see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
 Packages: libglib2.0-dev
 
@@ -19,7 +19,7 @@ To install on Ubuntu
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd CANReaderAndPublisher 
@@ -29,4 +29,4 @@ $ make
 $ ./polysync-can-reader-and-publisher-cpp 1
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/CANWriter/README.md
+++ b/CANWriter/README.md
@@ -1,3 +1,20 @@
-This example demonstrates connecting to a CAN device and writing data.
+### CANWriter
+Using the PolySync state machine this example does a simple CAN read in OK the state.
+This example will give you experience for the times you need a node to publish data to a CAN channel.
 
-For more API examples and tutorials, visit the PolySync Knowledgebase [here](https://support.harbrick.com/hc/en-us/articles/216968458)
+### Hardware requirements
+- linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd CANWriter 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+# You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
+$ ./polysync-can-writer-cpp 1
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/CANWriter/README.md
+++ b/CANWriter/README.md
@@ -1,14 +1,26 @@
 ### CANWriter
+
 Using the PolySync state machine this example does a simple CAN read in OK the state.
 This example will give you experience for the times you need a node to publish data to a CAN channel.
 
 ### Hardware requirements
+
 - linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
 
 ### Dependencies
+
 You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd CANWriter 
 $ mkdir build && cd build

--- a/CANWriter/README.md
+++ b/CANWriter/README.md
@@ -6,6 +6,7 @@ This example will give you experience for the times you need a node to publish d
 - linuxcan-compatible hardware is connected, i.e. a Kvaser Leaf Light
 
 ### Dependencies
+You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
 ### Building and Running the Node
 ```bash
@@ -13,7 +14,6 @@ $ cd CANWriter
 $ mkdir build && cd build
 $ cmake ..
 $ make
-# You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 $ ./polysync-can-writer-cpp 1
 ```
 

--- a/CANWriter/README.md
+++ b/CANWriter/README.md
@@ -1,7 +1,7 @@
 ### CANWriter
 
-Using the PolySync state machine this example does a simple CAN read in OK the state.
-This example will give you experience for the times you need a node to publish data to a CAN channel.
+Using the PolySync state machine, this example performs a simple CAN read in the OK state.
+This example also acts as a guide for when you need a node to publish data to a CAN channel.
 
 ### Hardware requirements
 
@@ -9,7 +9,7 @@ This example will give you experience for the times you need a node to publish d
 
 ### Dependencies
 
-You need to have an CAN channel to run this example see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
+You need to have a CAN channel to run this example, see:  [Connecting To A CAN Sensor](https://help.polysync.io/articles/configuration/runtime-node-configuration/connecting-to-a-can-radar-sensor/)
 
 Packages: libglib2.0-dev
 
@@ -19,7 +19,7 @@ To install on Ubuntu
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd CANWriter 
@@ -29,4 +29,4 @@ $ make
 $ ./polysync-can-writer-cpp 1
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/CSVExporter/README.md
+++ b/CSVExporter/README.md
@@ -1,0 +1,23 @@
+### CSVExporter
+Subscribes to a limited set of message types (below), and writes the incoming data to a CSV file (one CSV file for each message type)
+   `ps_platform_motion_msg`
+   `ps_objects_msg`
+   `ps_lane_model_msg`
+   `ps_lidar_points_msg`
+   `ps_radar_targets_msg`
+   `ps_traffic_sign_msg`
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd CSVExporter 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-csv-export
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/CSVExporter/README.md
+++ b/CSVExporter/README.md
@@ -1,6 +1,7 @@
 ### CSVExporter
 
-Subscribes to a limited set of message types (below), and writes the incoming data to a CSV file (one CSV file for each message type)
+This subscribes to a limited set of message types (below), and writes the incoming data to a CSV file (one CSV file for each message type):
+
    `ps_platform_motion_msg`
    `ps_objects_msg`
    `ps_lane_model_msg`
@@ -12,13 +13,13 @@ Subscribes to a limited set of message types (below), and writes the incoming da
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd CSVExporter 
@@ -28,4 +29,4 @@ $ make
 $ ./polysync-csv-export
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/CSVExporter/README.md
+++ b/CSVExporter/README.md
@@ -1,4 +1,5 @@
 ### CSVExporter
+
 Subscribes to a limited set of message types (below), and writes the incoming data to a CSV file (one CSV file for each message type)
    `ps_platform_motion_msg`
    `ps_objects_msg`
@@ -7,11 +8,18 @@ Subscribes to a limited set of message types (below), and writes the incoming da
    `ps_radar_targets_msg`
    `ps_traffic_sign_msg`
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd CSVExporter 
 $ mkdir build && cd build

--- a/DataGenerator/README.md
+++ b/DataGenerator/README.md
@@ -1,0 +1,26 @@
+### DataGenerator
+This example covers how to populate and publish data from a single node into a PolySync message on the bus, 
+enable multiple nodes to subscribe to messages to access data asynchronously, and visualize all data being 
+published to the PolySync bus.
+
+This example generates data and publishes it on the PolySync bus by generating fake radar, lidar and object data.
+It periodically publishes `ps_lidar_points_msg`, `ps_radar_targets_msg` and `ps_objects_msg` to the bus in OK state.
+It uses a lightweight diagnostic tool to tell if a system is properly up and running. 
+
+There is an article in our help center that describes the C++ version of this example.
+[Data Generation Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/data-generation-tutorial/)
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd DataGenerator 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-data-generator-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/DataGenerator/README.md
+++ b/DataGenerator/README.md
@@ -1,4 +1,5 @@
 ### DataGenerator
+
 This example covers how to populate and publish data from a single node into a PolySync message on the bus, 
 enable multiple nodes to subscribe to messages to access data asynchronously, and visualize all data being 
 published to the PolySync bus.
@@ -10,11 +11,18 @@ It uses a lightweight diagnostic tool to tell if a system is properly up and run
 There is an article in our help center that describes the C++ version of this example.
 [Data Generation Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/data-generation-tutorial/)
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd DataGenerator 
 $ mkdir build && cd build

--- a/DataGenerator/README.md
+++ b/DataGenerator/README.md
@@ -4,24 +4,24 @@ This example covers how to populate and publish data from a single node into a P
 enable multiple nodes to subscribe to messages to access data asynchronously, and visualize all data being 
 published to the PolySync bus.
 
-This example generates data and publishes it on the PolySync bus by generating fake radar, lidar and object data.
-It periodically publishes `ps_lidar_points_msg`, `ps_radar_targets_msg` and `ps_objects_msg` to the bus in OK state.
+This example generates data and publishes it on the PolySync bus by generating fake radar, lidar, and object data.
+It periodically publishes `ps_lidar_points_msg`, `ps_radar_targets_msg`, and `ps_objects_msg` to the bus in the OK state.
 It uses a lightweight diagnostic tool to tell if a system is properly up and running. 
 
-There is an article in our help center that describes the C++ version of this example.
+There is an article in the PolySync Help Center that describes the C++ version of this example:
 [Data Generation Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/data-generation-tutorial/)
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd DataGenerator 
@@ -31,4 +31,4 @@ $ make
 $ ./polysync-data-generator-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/Echo/README.md
+++ b/Echo/README.md
@@ -1,13 +1,21 @@
 ### Echo
+
 This is more of a tool then an example; it is a lightweight way of printing what messages are on the bus from the command line.
 The help output of this tool is very verbose and is the best way to get acquainted with its functionality.
 Sometimes this tools gets bogged down with very large message types such as `ps_lidar_points_msg`.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd Echo 
 $ mkdir build && cd build

--- a/Echo/README.md
+++ b/Echo/README.md
@@ -1,20 +1,20 @@
 ### Echo
 
-This is more of a tool then an example; it is a lightweight way of printing what messages are on the bus from the command line.
+This is more of a tool than an example. It is a lightweight way of printing what messages are on the bus from the command line.
 The help output of this tool is very verbose and is the best way to get acquainted with its functionality.
-Sometimes this tools gets bogged down with very large message types such as `ps_lidar_points_msg`.
+Sometimes this tools gets bogged down with very large message types, such as `ps_lidar_points_msg`.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd Echo 
@@ -24,4 +24,4 @@ $ make
 $ ./polysync-echo
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/Echo/README.md
+++ b/Echo/README.md
@@ -1,0 +1,19 @@
+### Echo
+This is more of a tool then an example; it is a lightweight way of printing what messages are on the bus from the command line.
+The help output of this tool is very verbose and is the best way to get acquainted with its functionality.
+Sometimes this tools gets bogged down with very large message types such as `ps_lidar_points_msg`.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd Echo 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-echo
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/FileTransfer/README.md
+++ b/FileTransfer/README.md
@@ -1,19 +1,19 @@
 ### FileTransfer
 
-This example shows you how to use the PolySync file transfer API to transfer files.  It transfers
+This example illustrates how to use the PolySync file transfer API to transfer files.  It transfers
 the PolySync EULA.txt file to a destination location.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd FileTransfer 
@@ -23,4 +23,4 @@ $ make
 $ ./polysync-file-transfer-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/FileTransfer/README.md
+++ b/FileTransfer/README.md
@@ -1,12 +1,20 @@
 ### FileTransfer
+
 This example shows you how to use the PolySync file transfer API to transfer files.  It transfers
 the PolySync EULA.txt file to a destination location.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd FileTransfer 
 $ mkdir build && cd build

--- a/FileTransfer/README.md
+++ b/FileTransfer/README.md
@@ -1,0 +1,18 @@
+### FileTransfer
+This example shows you how to use the PolySync file transfer API to transfer files.  It transfers
+the PolySync EULA.txt file to a destination location.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd FileTransfer 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-file-transfer-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/GroundPlaneDetection/README.md
+++ b/GroundPlaneDetection/README.md
@@ -1,0 +1,19 @@
+### Echo
+This example will introduce you to a common process for implementing perception algorithms, as well as using logfile data as an algorithm development acceleration tool.
+
+See the [Ground Plane Detection Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/ground-plane-detection-tutorial/) for a detailed description.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd Echo 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-echo
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/GroundPlaneDetection/README.md
+++ b/GroundPlaneDetection/README.md
@@ -1,6 +1,6 @@
 ### Echo
 
-This example will introduce you to a common process for implementing perception algorithms, as well as using logfile data as an algorithm development acceleration tool.
+This example illustrates a common process for implementing perception algorithms, and using logfile data as an algorithm development acceleration tool.
 
 See the [Ground Plane Detection Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/ground-plane-detection-tutorial/) for a detailed description.
 
@@ -8,13 +8,13 @@ See the [Ground Plane Detection Tutorial](https://help.polysync.io/articles/tuto
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd Echo 
@@ -24,4 +24,4 @@ $ make
 $ ./polysync-echo
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/GroundPlaneDetection/README.md
+++ b/GroundPlaneDetection/README.md
@@ -1,13 +1,21 @@
 ### Echo
+
 This example will introduce you to a common process for implementing perception algorithms, as well as using logfile data as an algorithm development acceleration tool.
 
 See the [Ground Plane Detection Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/ground-plane-detection-tutorial/) for a detailed description.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd Echo 
 $ mkdir build && cd build

--- a/HelloWorld/README.md
+++ b/HelloWorld/README.md
@@ -1,3 +1,3 @@
 This code is part of a tutorial in which we show demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
 
-The full tutorial can be found in the PolySync Knowledgebase [here](https://support.harbrick.com/hc/en-us/articles/216968458)
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/HelloWorld/README.md
+++ b/HelloWorld/README.md
@@ -1,18 +1,18 @@
 ### HelloWorld
 
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
+This code is part of a tutorial that demonstrates the basics of connecting to the PolySync bus. This allows you to read and write information.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd HelloWorld 
@@ -22,4 +22,4 @@ $ make
 $ ./polysync-helloworld-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/HelloWorld/README.md
+++ b/HelloWorld/README.md
@@ -1,11 +1,19 @@
 ### HelloWorld
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
 
-### Hardware requirements
+This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
 
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd HelloWorld 
 $ mkdir build && cd build

--- a/HelloWorldPublisher/README.md
+++ b/HelloWorldPublisher/README.md
@@ -6,13 +6,13 @@ This example is the most basic C++ application you can have that publishes data 
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd HelloWorldPublisher 
@@ -22,4 +22,4 @@ $ make
 $ ./polysync-helloworld-publisher-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/HelloWorldPublisher/README.md
+++ b/HelloWorldPublisher/README.md
@@ -1,5 +1,5 @@
-### HelloWorld
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
+### HelloWorldPublisher
+This example is the most basic C++ application you can have that publishes data to the PolySync bus.
 
 ### Hardware requirements
 
@@ -7,11 +7,11 @@ This code is part of a tutorial in which we demonstrate the basics of connecting
 
 ### Building and Running the Node
 ```bash
-$ cd HelloWorld 
+$ cd HelloWorldPublisher 
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ ./polysync-helloworld-cpp
+$ ./polysync-helloworld-publisher-cpp
 ```
 
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/HelloWorldPublisher/README.md
+++ b/HelloWorldPublisher/README.md
@@ -1,11 +1,19 @@
 ### HelloWorldPublisher
-This example is the most basic C++ application you can have that publishes data to the PolySync bus.
 
-### Hardware requirements
+This example is the most basic C++ application you can have that publishes data to the PolySync bus.
 
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd HelloWorldPublisher 
 $ mkdir build && cd build

--- a/HelloWorldSubscriber/README.md
+++ b/HelloWorldSubscriber/README.md
@@ -1,5 +1,5 @@
-### HelloWorld
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
+### HelloWorldSubscriber
+This example is the most basic C++ application you can have that subscribes to data through high-level messages from the PolySync bus.
 
 ### Hardware requirements
 
@@ -7,11 +7,11 @@ This code is part of a tutorial in which we demonstrate the basics of connecting
 
 ### Building and Running the Node
 ```bash
-$ cd HelloWorld 
+$ cd HelloWorldSubscriber 
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ ./polysync-helloworld-cpp
+$ ./polysync-helloworld-subscriber-cpp
 ```
 
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/HelloWorldSubscriber/README.md
+++ b/HelloWorldSubscriber/README.md
@@ -1,11 +1,19 @@
 ### HelloWorldSubscriber
-This example is the most basic C++ application you can have that subscribes to data through high-level messages from the PolySync bus.
 
-### Hardware requirements
+This example is the most basic C++ application you can have that subscribes to data through high-level messages from the PolySync bus.
 
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd HelloWorldSubscriber 
 $ mkdir build && cd build

--- a/HelloWorldSubscriber/README.md
+++ b/HelloWorldSubscriber/README.md
@@ -6,13 +6,13 @@ This example is the most basic C++ application you can have that subscribes to d
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd HelloWorldSubscriber 
@@ -22,4 +22,4 @@ $ make
 $ ./polysync-helloworld-subscriber-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/LogSessionExport/README.md
+++ b/LogSessionExport/README.md
@@ -1,5 +1,5 @@
-### HelloWorld
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
+### LogSessionExport
+This example demonstrates how to use the PolySync Log Session Transfer API to export a recorded log session, so that it can be imported and replayed on any other PolySync system.
 
 ### Hardware requirements
 
@@ -7,11 +7,11 @@ This code is part of a tutorial in which we demonstrate the basics of connecting
 
 ### Building and Running the Node
 ```bash
-$ cd HelloWorld 
+$ cd LogSessionExport 
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ ./polysync-helloworld-cpp
+$ ./polysync-log-session-export-cpp
 ```
 
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/LogSessionExport/README.md
+++ b/LogSessionExport/README.md
@@ -1,11 +1,19 @@
 ### LogSessionExport
-This example demonstrates how to use the PolySync Log Session Transfer API to export a recorded log session, so that it can be imported and replayed on any other PolySync system.
 
-### Hardware requirements
+This example demonstrates how to use the PolySync Log Session Transfer API to export a recorded log session, so that it can be imported and replayed on any other PolySync system.
 
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd LogSessionExport 
 $ mkdir build && cd build

--- a/LogSessionExport/README.md
+++ b/LogSessionExport/README.md
@@ -6,13 +6,13 @@ This example demonstrates how to use the PolySync Log Session Transfer API to ex
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd LogSessionExport 
@@ -22,4 +22,4 @@ $ make
 $ ./polysync-log-session-export-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/LogSessionImport/README.md
+++ b/LogSessionImport/README.md
@@ -1,18 +1,18 @@
 ### LogSessionImport
 
-This example demonstrates how to use the PolySync Log Session Transfer API to import a previously exported log session to a new distributed system
+This example demonstrates how to use the PolySync Log Session Transfer API to import a previously exported log session to a new distributed system.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd LogSessionImport 
@@ -22,4 +22,4 @@ $ make
 $ ./polysync-log-session-import-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/LogSessionImport/README.md
+++ b/LogSessionImport/README.md
@@ -1,5 +1,5 @@
-### HelloWorld
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
+### LogSessionImport
+This example demonstrates how to use the PolySync Log Session Transfer API to import a previously exported log session to a new distributed system
 
 ### Hardware requirements
 
@@ -7,11 +7,11 @@ This code is part of a tutorial in which we demonstrate the basics of connecting
 
 ### Building and Running the Node
 ```bash
-$ cd HelloWorld 
+$ cd LogSessionImport 
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ ./polysync-helloworld-cpp
+$ ./polysync-log-session-import-cpp
 ```
 
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/LogSessionImport/README.md
+++ b/LogSessionImport/README.md
@@ -1,11 +1,19 @@
 ### LogSessionImport
-This example demonstrates how to use the PolySync Log Session Transfer API to import a previously exported log session to a new distributed system
 
-### Hardware requirements
+This example demonstrates how to use the PolySync Log Session Transfer API to import a previously exported log session to a new distributed system
 
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd LogSessionImport 
 $ mkdir build && cd build

--- a/LogfileIterator/README.md
+++ b/LogfileIterator/README.md
@@ -1,27 +1,27 @@
 ### LogfileIterator
 
-This example is very powerful and very popular. It uses the logfile API.
+This example is very powerful and very popular, and it uses the logfile API.
 It allows a user to iterate over a specified logfile manually and read its contents.
 A logfile iterator callback is set up, which is called every time a new “record” is popped from the logfile. 
-This example then prints some details from the header of each of the records
-The logfile iteration happens many times faster than real time.
-Be aware lot of people have issues with this example because they don’t realize that just because a message publishes 
+This example then prints some details from the header of each of the records.
+The logfile iteration happens much faster than real time.
+Be aware that a lot of people have issues with this example because they don’t realize that just because a message publishes 
 a message type doesn’t mean it logs that same message type. 
 
-For example most CAN drivers log with `ps_can_frame_msg` but publish `ps_radar_targets_msg`, `ps_objects_msg` etc. 
-This results in them trying to cast new logfile frames to `ps_radar_targets_msg` etc instead of their actual format.
+For example most CAN drivers log with `ps_can_frame_msg` but publish `ps_radar_targets_msg`, `ps_objects_msg`, etc. 
+This results in them trying to cast new logfile frames to `ps_radar_targets_msg` etc., instead of their actual format.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd LogfileIterator
@@ -31,4 +31,4 @@ $ make
 $ ./polysync-logfile-iterator-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/LogfileIterator/README.md
+++ b/LogfileIterator/README.md
@@ -1,0 +1,26 @@
+### LogfileIterator
+This example is very powerful and very popular. It uses the logfile API.
+It allows a user to iterate over a specified logfile manually and read its contents.
+A logfile iterator callback is set up, which is called every time a new “record” is popped from the logfile. 
+This example then prints some details from the header of each of the records
+The logfile iteration happens many times faster than real time.
+Be aware lot of people have issues with this example because they don’t realize that just because a message publishes 
+a message type doesn’t mean it logs that same message type. 
+
+For example most CAN drivers log with `ps_can_frame_msg` but publish `ps_radar_targets_msg`, `ps_objects_msg` etc. 
+This results in them trying to cast new logfile frames to `ps_radar_targets_msg` etc instead of their actual format.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd LogfileIterator
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-logfile-iterator-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/LogfileIterator/README.md
+++ b/LogfileIterator/README.md
@@ -1,4 +1,5 @@
 ### LogfileIterator
+
 This example is very powerful and very popular. It uses the logfile API.
 It allows a user to iterate over a specified logfile manually and read its contents.
 A logfile iterator callback is set up, which is called every time a new “record” is popped from the logfile. 
@@ -10,11 +11,18 @@ a message type doesn’t mean it logs that same message type.
 For example most CAN drivers log with `ps_can_frame_msg` but publish `ps_radar_targets_msg`, `ps_objects_msg` etc. 
 This results in them trying to cast new logfile frames to `ps_radar_targets_msg` etc instead of their actual format.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd LogfileIterator
 $ mkdir build && cd build

--- a/LogfileQueueReader/README.md
+++ b/LogfileQueueReader/README.md
@@ -1,25 +1,25 @@
 ### LogfileQueueReader
 
-This is example is useful when you want to access the raw sensor data, just as it was sent on the wire, before the dynamic driver processes and abstracts the data
+This example is useful when you want to access raw sensor data, just as it was sent on the wire, before the dynamic driver processes and abstracts the data.
 
-{{% note %}} This does not effect the functionality of the dynamic driver, it will still process and publish the high-level message types, as defined in the SDF Configurator node entry. {{% /note %}}
+{{% note %}} This does not effect the functionality of the dynamic driver. It will still process and publish the high-level message types, as defined in the SDF Configurator node entry. {{% /note %}}
 
 You would use this node if you wanted to filter or pre-process the sensor data before it’s published to the PolySync bus.
 
 This is an example of a node that uses the Logfile API routines to replay a PolySync logfile using the message queue instead of subscribing to a high-level PolySync message type.
-This node accesses the raw, non-abstracted `plog` data, and leverging the dynamic driver Hardware Abstraction Layer (HAL) header file to cast the raw data to low-level OEM defined C structs.
+This node accesses the raw, non-abstracted `plog` data, and leverages the dynamic driver Hardware Abstraction Layer (HAL) header file to cast the raw data to low-level OEM defined C structs.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd LogfileQueueReader 
@@ -29,4 +29,4 @@ $ make
 $ ./polysync-logfile-queue-reader-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/LogfileQueueReader/README.md
+++ b/LogfileQueueReader/README.md
@@ -1,4 +1,5 @@
 ### LogfileQueueReader
+
 This is example is useful when you want to access the raw sensor data, just as it was sent on the wire, before the dynamic driver processes and abstracts the data
 
 {{% note %}} This does not effect the functionality of the dynamic driver, it will still process and publish the high-level message types, as defined in the SDF Configurator node entry. {{% /note %}}
@@ -8,11 +9,18 @@ You would use this node if you wanted to filter or pre-process the sensor data b
 This is an example of a node that uses the Logfile API routines to replay a PolySync logfile using the message queue instead of subscribing to a high-level PolySync message type.
 This node accesses the raw, non-abstracted `plog` data, and leverging the dynamic driver Hardware Abstraction Layer (HAL) header file to cast the raw data to low-level OEM defined C structs.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd LogfileQueueReader 
 $ mkdir build && cd build

--- a/LogfileQueueReader/README.md
+++ b/LogfileQueueReader/README.md
@@ -1,0 +1,24 @@
+### LogfileQueueReader
+This is example is useful when you want to access the raw sensor data, just as it was sent on the wire, before the dynamic driver processes and abstracts the data
+
+{{% note %}} This does not effect the functionality of the dynamic driver, it will still process and publish the high-level message types, as defined in the SDF Configurator node entry. {{% /note %}}
+
+You would use this node if you wanted to filter or pre-process the sensor data before it’s published to the PolySync bus.
+
+This is an example of a node that uses the Logfile API routines to replay a PolySync logfile using the message queue instead of subscribing to a high-level PolySync message type.
+This node accesses the raw, non-abstracted `plog` data, and leverging the dynamic driver Hardware Abstraction Layer (HAL) header file to cast the raw data to low-level OEM defined C structs.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd LogfileQueueReader 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-logfile-queue-reader-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/LogfileReader/README.md
+++ b/LogfileReader/README.md
@@ -1,0 +1,23 @@
+### LogfileReader
+This example uses the Logfile API to replay a PolySync logfile `plog` file.
+It Depends on a file in `/tmp/` directory, but can easily be updated to point to any existing `plog` file (the intention of the example)
+   /tmp/polysync_logfile.plog
+Steps to run: 
+   1. Update the file `src/logfile_reader.c` on line 74 to point to an existing `plog` file, (point to new rnr_logs location)
+   2. Compile
+   3. Run
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd LogfileReader 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-logfile-reader-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/LogfileReader/README.md
+++ b/LogfileReader/README.md
@@ -1,4 +1,5 @@
 ### LogfileReader
+
 This example uses the Logfile API to replay a PolySync logfile `plog` file.
 It Depends on a file in `/tmp/` directory, but can easily be updated to point to any existing `plog` file (the intention of the example)
    /tmp/polysync_logfile.plog
@@ -7,11 +8,18 @@ Steps to run:
    2. Compile
    3. Run
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd LogfileReader 
 $ mkdir build && cd build

--- a/LogfileReader/README.md
+++ b/LogfileReader/README.md
@@ -1,9 +1,11 @@
 ### LogfileReader
 
 This example uses the Logfile API to replay a PolySync logfile `plog` file.
-It Depends on a file in `/tmp/` directory, but can easily be updated to point to any existing `plog` file (the intention of the example)
+Even though it depends on a file in the `/tmp/` directory, it can still be easily updated to point to any existing `plog` file (the intention of the example).
    /tmp/polysync_logfile.plog
+
 Steps to run: 
+
    1. Update the file `src/logfile_reader.c` on line 74 to point to an existing `plog` file, (point to new rnr_logs location)
    2. Compile
    3. Run
@@ -12,13 +14,13 @@ Steps to run:
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd LogfileReader 
@@ -28,4 +30,4 @@ $ make
 $ ./polysync-logfile-reader-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/LogfileWriter/README.md
+++ b/LogfileWriter/README.md
@@ -1,0 +1,18 @@
+### LogfileWriter
+This is an example that uses the Logfile API to replay a PolySync logfile `plog` file
+Shows how to use the Logfile API routines to write a PolySync byte array message to a PolySync logfile `plog`
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd LogfileWriter 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-logfile-writer-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/LogfileWriter/README.md
+++ b/LogfileWriter/README.md
@@ -1,19 +1,19 @@
 ### LogfileWriter
 
-This is an example that uses the Logfile API to replay a PolySync logfile `plog` file
-Shows how to use the Logfile API routines to write a PolySync byte array message to a PolySync logfile `plog`
+This is an example that uses the Logfile API to replay a PolySync logfile `plog` file.
+It shows how to use the Logfile API routines to write a PolySync byte array message to a PolySync logfile `plog`.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd LogfileWriter 
@@ -23,4 +23,4 @@ $ make
 $ ./polysync-logfile-writer-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/LogfileWriter/README.md
+++ b/LogfileWriter/README.md
@@ -1,12 +1,20 @@
 ### LogfileWriter
+
 This is an example that uses the Logfile API to replay a PolySync logfile `plog` file
 Shows how to use the Logfile API routines to write a PolySync byte array message to a PolySync logfile `plog`
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd LogfileWriter 
 $ mkdir build && cd build

--- a/ParameterGetSet/README.md
+++ b/ParameterGetSet/README.md
@@ -1,0 +1,20 @@
+### ParameterGetSet
+This example demonstrates the logic used to filter for a specific node on the bus, and use the Parameter get/set API to update a specific parameter ID at runtime
+It publishes and subscribes the `ps_parameters_msg`
+It checks and then updates the coordinate frame identifier, specifically for a video device node
+
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd ParameterGetSet 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-parameter-get-set-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/ParameterGetSet/README.md
+++ b/ParameterGetSet/README.md
@@ -1,14 +1,21 @@
 ### ParameterGetSet
+
 This example demonstrates the logic used to filter for a specific node on the bus, and use the Parameter get/set API to update a specific parameter ID at runtime
 It publishes and subscribes the `ps_parameters_msg`
 It checks and then updates the coordinate frame identifier, specifically for a video device node
 
-
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd ParameterGetSet 
 $ mkdir build && cd build

--- a/ParameterGetSet/README.md
+++ b/ParameterGetSet/README.md
@@ -1,20 +1,19 @@
 ### ParameterGetSet
 
-This example demonstrates the logic used to filter for a specific node on the bus, and use the Parameter get/set API to update a specific parameter ID at runtime
-It publishes and subscribes the `ps_parameters_msg`
-It checks and then updates the coordinate frame identifier, specifically for a video device node
+This example demonstrates the logic used to filter for a specific node on the bus, and uses the ParameterGetSet API to update a specific parameter ID at runtime.
+It publishes and subscribes the `ps_parameters_msg`, and checks and then updates the coordinate frame identifier, specifically for a video device node.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd ParameterGetSet 
@@ -24,4 +23,4 @@ $ make
 $ ./polysync-parameter-get-set-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/PathPlanner/README.md
+++ b/PathPlanner/README.md
@@ -1,0 +1,23 @@
+### PathPlanner
+This is a C++ algorithm example.
+This example will build a basic path planner algorithm in PolySync. We will apply a basic A\* planner to a simulated search space, generate the optimal path to the goal state, and then move a simulated robot along that path to the goal. The optimal path is sent one waypoint at a time as a `PlatformMotionMessage`, which is defined in the [C++ Sensor Data Model](http://polysync.github.io/Docs-2.0/#platformmotionmessage) Module.
+
+For a detailed description see:  [Path Planner Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/path-planner-tutorial/)
+
+### Hardware requirements
+
+### Dependencies
+[OpenCV for Linux/Mac - Version 2.4.13](https://github.com/Itseez/opencv/archive/2.4.13.zip)
+
+### Building and Running the Node
+```bash
+$ cd PathPlanner 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-path-planner-robot-cpp
+# In another terminal window, run the planner node
+$ ./polysync-path-planner-algorithm-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/PathPlanner/README.md
+++ b/PathPlanner/README.md
@@ -1,15 +1,24 @@
 ### PathPlanner
+
 This is a C++ algorithm example.
 This example will build a basic path planner algorithm in PolySync. We will apply a basic A\* planner to a simulated search space, generate the optimal path to the goal state, and then move a simulated robot along that path to the goal. The optimal path is sent one waypoint at a time as a `PlatformMotionMessage`, which is defined in the [C++ Sensor Data Model](http://polysync.github.io/Docs-2.0/#platformmotionmessage) Module.
 
 For a detailed description see:  [Path Planner Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/path-planner-tutorial/)
 
-### Hardware requirements
-
 ### Dependencies
+
 [OpenCV for Linux/Mac - Version 2.4.13](https://github.com/Itseez/opencv/archive/2.4.13.zip)
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd PathPlanner 
 $ mkdir build && cd build

--- a/PathPlanner/README.md
+++ b/PathPlanner/README.md
@@ -3,7 +3,7 @@
 This is a C++ algorithm example.
 This example will build a basic path planner algorithm in PolySync. We will apply a basic A\* planner to a simulated search space, generate the optimal path to the goal state, and then move a simulated robot along that path to the goal. The optimal path is sent one waypoint at a time as a `PlatformMotionMessage`, which is defined in the [C++ Sensor Data Model](http://polysync.github.io/Docs-2.0/#platformmotionmessage) Module.
 
-For a detailed description see:  [Path Planner Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/path-planner-tutorial/)
+For a detailed description, see:  [Path Planner Tutorial](https://help.polysync.io/articles/tutorials-and-examples/tutorials/path-planner-tutorial/).
 
 ### Dependencies
 
@@ -11,13 +11,13 @@ For a detailed description see:  [Path Planner Tutorial](https://help.polysync.i
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd PathPlanner 
@@ -29,4 +29,4 @@ $ ./polysync-path-planner-robot-cpp
 $ ./polysync-path-planner-algorithm-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/PublishSubscribe/PublishSubscribe.cpp
+++ b/PublishSubscribe/PublishSubscribe.cpp
@@ -47,7 +47,7 @@ using namespace std;
 /**
  * @brief Node flags to be OR'd with driver/interface flags.
  *
- * Provided by the compiler so Harbrick can add build-specifics as needed.
+ * Provided by the compiler so PolySync can add build-specifics as needed.
  *
  */
 #ifndef NODE_FLAGS_VALUE

--- a/PublishSubscribe/README.md
+++ b/PublishSubscribe/README.md
@@ -1,0 +1,19 @@
+### PublishSubscribe
+This example shows simple publish and subscribe functionality in PolySync.
+It publishes an empty `ps_event_msg` to show how the publish functionality works in PolySync.
+It subscribes to all diagnostic messages on the PolySync bus and then prints the info each diagnostic message contains, as they are received in real time.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd PublishSubscribe 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-publisher-subscriber-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/PublishSubscribe/README.md
+++ b/PublishSubscribe/README.md
@@ -1,20 +1,20 @@
 ### PublishSubscribe
 
-This example shows simple publish and subscribe functionality in PolySync.
-It publishes an empty `ps_event_msg` to show how the publish functionality works in PolySync.
-It subscribes to all diagnostic messages on the PolySync bus and then prints the info each diagnostic message contains, as they are received in real time.
+This example illustrates the simple publish and subscribe functionality found in PolySync.
+It publishes an empty `ps_event_msg` to demonstrate how the publish functionality works in PolySync.
+It subscribes to all diagnostic messages on the PolySync bus, and then prints the info each diagnostic message contains as they are received in real time.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd PublishSubscribe 
@@ -24,4 +24,4 @@ $ make
 $ ./polysync-publisher-subscriber-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/PublishSubscribe/README.md
+++ b/PublishSubscribe/README.md
@@ -1,13 +1,21 @@
 ### PublishSubscribe
+
 This example shows simple publish and subscribe functionality in PolySync.
 It publishes an empty `ps_event_msg` to show how the publish functionality works in PolySync.
 It subscribes to all diagnostic messages on the PolySync bus and then prints the info each diagnostic message contains, as they are received in real time.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd PublishSubscribe 
 $ mkdir build && cd build

--- a/QtImageViewer/README.md
+++ b/QtImageViewer/README.md
@@ -1,11 +1,11 @@
 ### QtImageViewer
 
 This is an example of a threaded C++ PolySync node.
-This code is an example application to demonstrate interaction with PolySync image data using the C++ PolySync APIs.
-It will visualize LiDAR, RADAR and object data from multiple sources in a Qt window.
-This example has tools to freeze-frame and measure distance; color by source or type; great for building sensor fusion applications.
+This code is an example application intended to demonstrate an interaction with PolySync image data using the C++ PolySync APIs.
+It will visualize LiDAR, RADAR, and object data from multiple sources in a Qt window.
+This example has tools to freeze frame and measure distance, color by source or type, and are great for building sensor fusion applications.
 The graphics were built with OpenGL and are very extendable.
-It has a built in system/node management tool to dynamically handle nodes coming on/off bus.
+It has a built-in system/node management tool to dynamically handle nodes coming on/off bus.
 
 ### Hardware requirements
 
@@ -20,13 +20,13 @@ Download and install Qt [here](http://www.qt.io/download/)
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd QtImageViewer 
@@ -36,7 +36,7 @@ $ make
 $ ./polysync-qt-image-viewer-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).
 
 
 

--- a/QtImageViewer/README.md
+++ b/QtImageViewer/README.md
@@ -1,4 +1,5 @@
 ### QtImageViewer
+
 This is an example of a threaded C++ PolySync node.
 This code is an example application to demonstrate interaction with PolySync image data using the C++ PolySync APIs.
 It will visualize LiDAR, RADAR and object data from multiple sources in a Qt window.
@@ -8,12 +9,25 @@ It has a built in system/node management tool to dynamically handle nodes coming
 
 ### Hardware requirements
 
+Sensors: LiDAR, RADAR
+Video Device
+
 ### Dependencies
+
 A system installation of Qt is required for this to compile.
 Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
 Download and install Qt [here](http://www.qt.io/download/)
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd QtImageViewer 
 $ mkdir build && cd build

--- a/QtImageViewer/README.md
+++ b/QtImageViewer/README.md
@@ -5,5 +5,5 @@ A system installation of Qt is required for this to compile.
 Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
 Download and install Qt [here](http://www.qt.io/download/)
 
-For more examples and tutorials, visit the PolySync Knowledge Base [here](https://support.harbrick.com/hc/en-us/articles/216968458)
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
 

--- a/QtImageViewer/README.md
+++ b/QtImageViewer/README.md
@@ -1,9 +1,29 @@
+### QtImageViewer
+This is an example of a threaded C++ PolySync node.
 This code is an example application to demonstrate interaction with PolySync image data using the C++ PolySync APIs.
+It will visualize LiDAR, RADAR and object data from multiple sources in a Qt window.
+This example has tools to freeze-frame and measure distance; color by source or type; great for building sensor fusion applications.
+The graphics were built with OpenGL and are very extendable.
+It has a built in system/node management tool to dynamically handle nodes coming on/off bus.
 
+### Hardware requirements
+
+### Dependencies
 A system installation of Qt is required for this to compile.
-
 Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
 Download and install Qt [here](http://www.qt.io/download/)
 
+### Building and Running the Node
+```bash
+$ cd QtImageViewer 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-qt-image-viewer-cpp
+```
+
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+
+
+
 

--- a/README.md
+++ b/README.md
@@ -4,35 +4,35 @@ Here you can find examples that demonstrate how to use PolySync's APIs.
 
 ## Core APIs
 
-- [HelloWorld](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/HelloWorld) - Create a node and process node-level events.
-- [HelloWorldPublisher](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/HelloWorldPublisher) - Publish a message from a node to the PolySync bus.
-- [HelloWorldSubscriber](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/HelloWorldSubscriber) - Subscribe a node to messages on the PolySync bus.
-- [Publish & Subscribe](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/PublishSubscribe) - Use publish/subscribe routines.
-- [Coordinate Transformation (single)](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/SingleTransform) - Use the Transform API to create transform coordinate frames.
-- [Coordinate Transformation (stack)](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/TransformStack) - Use the Transform API to transform coordinate frames using a stack.
-- [Sample Application](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/SampleApplication) - Create an application node.
+- [HelloWorld](https://github.com/PolySync-Core-CPP-Examples/tree/master/HelloWorld) - Create a node and process node-level events.
+- [HelloWorldPublisher](https://github.com/PolySync-Core-CPP-Examples/tree/master/HelloWorldPublisher) - Publish a message from a node to the PolySync bus.
+- [HelloWorldSubscriber](https://github.com/PolySync-Core-CPP-Examples/tree/master/HelloWorldSubscriber) - Subscribe a node to messages on the PolySync bus.
+- [Publish & Subscribe](https://github.com/PolySync-Core-CPP-Examples/tree/master/PublishSubscribe) - Use publish/subscribe routines.
+- [Coordinate Transformation (single)](https://github.com/PolySync-Core-CPP-Examples/tree/master/SingleTransform) - Use the Transform API to create transform coordinate frames.
+- [Coordinate Transformation (stack)](https://github.com/PolySync-Core-CPP-Examples/tree/master/TransformStack) - Use the Transform API to transform coordinate frames using a stack.
+- [Sample Application](https://github.com/PolySync-Core-CPP-Examples/tree/master/SampleApplication) - Create an application node.
 
 ## Message APIs
 
-- [Shared Memory Image Data Viewer](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/SharedMemoryImageDataViewer) - View image data received over the PolySync shared memory queue.
-- [Paramater Get/Set](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/ParameterGetSet) - Get/set parameters from the PolySync bus.
+- [Shared Memory Image Data Viewer](https://github.com/PolySync-Core-CPP-Examples/tree/master/SharedMemoryImageDataViewer) - View image data received over the PolySync shared memory queue.
+- [Paramater Get/Set](https://github.com/PolySync-Core-CPP-Examples/tree/master/ParameterGetSet) - Get/set parameters from the PolySync bus.
  
 ## Device APIs
 
-- [Socket Reader](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/SocketReader) - Read data from a network device. 
-- [Socket Writer](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/SocketWriter) - Write data to a network device.
-- [Serial Reader](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/SerialReader) - Read data from a serial device. 
-- [Serial Writer](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/SerialWriter) - Write data to a serial device.
-- [CAN Reader](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/CANReader) - Read data from a CAN device. 
-- [CAN Writer](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/CANWriter) - Write data to a CAN device.
-- [Video Device Viewer](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/VideoDeviceViewer) - Interact with a Video Device.
-- [Video Device With Encode/Decode](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/VideoEncodeDecode) - Communicate with a video device, encode, and decode video data.
+- [Socket Reader](https://github.com/PolySync-Core-CPP-Examples/tree/master/SocketReader) - Read data from a network device. 
+- [Socket Writer](https://github.com/PolySync-Core-CPP-Examples/tree/master/SocketWriter) - Write data to a network device.
+- [Serial Reader](https://github.com/PolySync-Core-CPP-Examples/tree/master/SerialReader) - Read data from a serial device. 
+- [Serial Writer](https://github.com/PolySync-Core-CPP-Examples/tree/master/SerialWriter) - Write data to a serial device.
+- [CAN Reader](https://github.com/PolySync-Core-CPP-Examples/tree/master/CANReader) - Read data from a CAN device. 
+- [CAN Writer](https://github.com/PolySync-Core-CPP-Examples/tree/master/CANWriter) - Write data to a CAN device.
+- [Video Device Viewer](https://github.com/PolySync-Core-CPP-Examples/tree/master/VideoDeviceViewer) - Interact with a Video Device.
+- [Video Device With Encode/Decode](https://github.com/PolySync-Core-CPP-Examples/tree/master/VideoEncodeDecode) - Communicate with a video device, encode, and decode video data.
 
 ## Utilities and Cool Stuff
 
-- [Data Generator](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/DataGenerator) - Publish various PolySync message types with pseudo-random data.
-- [Record](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/Record) - Record PolySync bus data.
-- [Replay](https://github.com/PolySync/PolySync-CPP-Examples/tree/master/Replay) - Replay PolySync bus data.
+- [Data Generator](https://github.com/PolySync-Core-CPP-Examples/tree/master/DataGenerator) - Publish various PolySync message types with pseudo-random data.
+- [Record](https://github.com/PolySync-Core-CPP-Examples/tree/master/Record) - Record PolySync bus data.
+- [Replay](https://github.com/PolySync-Core-CPP-Examples/tree/master/Replay) - Replay PolySync bus data.
 
 
 ## PolySync Resources

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Here you can find examples that demonstrate how to use PolySync's APIs.
 
 
 ## PolySync Resources
-- [Complete List of Examples](https://support.harbrick.com/hc/en-us/articles/216961138)
-- [Knowledge Base](https://support.harbrick.com/hc/en-us)
-- [Support Center](https://support.harbrick.com/)
+- [Complete List of Examples](https://help.polysync.io/articles/)
+- [Help Center](https://help.polysync.io)
 
 

--- a/Record/README.md
+++ b/Record/README.md
@@ -1,24 +1,24 @@
 ### Record
 
-Record is more of a tool than an example; it exposes much of the functionality of the RecordSession API as a command line tool.
-This is an interactive application which expects you to enter the record session ID.  It allows you to stop the recording.
-As an example this code exposes to the user how to properly access the RecordSession APIs functionality.
+Record is more of a tool than an example. It exposes much of the functionality of the RecordSession API as a command line tool.
+This is an interactive application, which expects you to enter the record session ID and allows you to stop the recording.
+As an example, this code illustrates how to properly access the RecordSession APIs functionality.
 
 ### Hardware requirements
 
-A sensor or video device
+A sensor or video device.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd Record 
@@ -28,4 +28,4 @@ $ make
 $ ./polysync-record-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/Record/README.md
+++ b/Record/README.md
@@ -1,0 +1,19 @@
+### Record
+Record is more of a tool than an example; it exposes much of the functionality of the RecordSession API as a command line tool.
+This is an interactive application which expects you to enter the record session ID.  It allows you to stop the recording.
+As an example this code exposes to the user how to properly access the RecordSession APIs functionality.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd Record 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-record-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/Record/README.md
+++ b/Record/README.md
@@ -1,13 +1,25 @@
 ### Record
+
 Record is more of a tool than an example; it exposes much of the functionality of the RecordSession API as a command line tool.
 This is an interactive application which expects you to enter the record session ID.  It allows you to stop the recording.
 As an example this code exposes to the user how to properly access the RecordSession APIs functionality.
 
 ### Hardware requirements
 
+A sensor or video device
+
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd Record 
 $ mkdir build && cd build

--- a/Replay/README.md
+++ b/Replay/README.md
@@ -1,0 +1,19 @@
+### Replay
+Replay is more of a tool than an example; it exposes much of the functionality of the ReplaySession API as a command line tool.
+This is an interactive application which expects you to enter the replay session ID.  It allows you to stop the replay.
+As an example this code exposes to the user how to properly access the RecordSession APIs functionality.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd Replay 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-record-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/Replay/README.md
+++ b/Replay/README.md
@@ -1,13 +1,21 @@
 ### Replay
+
 Replay is more of a tool than an example; it exposes much of the functionality of the ReplaySession API as a command line tool.
 This is an interactive application which expects you to enter the replay session ID.  It allows you to stop the replay.
 As an example this code exposes to the user how to properly access the RecordSession APIs functionality.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd Replay 
 $ mkdir build && cd build

--- a/Replay/README.md
+++ b/Replay/README.md
@@ -1,20 +1,20 @@
 ### Replay
 
-Replay is more of a tool than an example; it exposes much of the functionality of the ReplaySession API as a command line tool.
-This is an interactive application which expects you to enter the replay session ID.  It allows you to stop the replay.
-As an example this code exposes to the user how to properly access the RecordSession APIs functionality.
+Replay is more of a tool than an example. It exposes much of the functionality of the ReplaySession API as a command line tool.
+This is an interactive application, which expects you to enter the replay session ID and allows you to stop the replay.
+As an example, this code illustrates how to properly access the RecordSession APIs functionality.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd Replay 
@@ -24,4 +24,4 @@ $ make
 $ ./polysync-record-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/SampleApplication/README.md
+++ b/SampleApplication/README.md
@@ -1,5 +1,5 @@
-### HelloWorld
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
+### SampleApplication
+This is an example of the application node template, as opposed to the node template
 
 ### Hardware requirements
 
@@ -7,11 +7,11 @@ This code is part of a tutorial in which we demonstrate the basics of connecting
 
 ### Building and Running the Node
 ```bash
-$ cd HelloWorld 
+$ cd SampleApplication 
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ ./polysync-helloworld-cpp
+$ ./polysync-sample-application-cpp
 ```
 
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SampleApplication/README.md
+++ b/SampleApplication/README.md
@@ -1,11 +1,19 @@
 ### SampleApplication
-This is an example of the application node template, as opposed to the node template
 
-### Hardware requirements
+This is an example of the application node template, as opposed to the node template
 
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd SampleApplication 
 $ mkdir build && cd build

--- a/SampleApplication/README.md
+++ b/SampleApplication/README.md
@@ -1,18 +1,18 @@
 ### SampleApplication
 
-This is an example of the application node template, as opposed to the node template
+This is an example of the application node template, as opposed to the node template.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SampleApplication 
@@ -22,4 +22,4 @@ $ make
 $ ./polysync-sample-application-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/SerialConfig/README.md
+++ b/SerialConfig/README.md
@@ -1,19 +1,19 @@
 ### SerialConfig
 
-This is an example of the Serial API to configure a serial port.
-It requires two serial ports, the example prints strings between the two ports.
+This is an example of the Serial API used to configure a serial port.
+It requires two serial ports, as the example prints strings between the two ports.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SerialConfig 
@@ -23,4 +23,4 @@ $ make
 $ ./polysync-serial-config-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/SerialConfig/README.md
+++ b/SerialConfig/README.md
@@ -1,12 +1,20 @@
 ### SerialConfig
+
 This is an example of the Serial API to configure a serial port.
 It requires two serial ports, the example prints strings between the two ports.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd SerialConfig 
 $ mkdir build && cd build

--- a/SerialConfig/README.md
+++ b/SerialConfig/README.md
@@ -1,5 +1,6 @@
-### HelloWorld
-This code is part of a tutorial in which we demonstrate the basics of connecting to the PolySync bus to allow you to read and write information.
+### SerialConfig
+This is an example of the Serial API to configure a serial port.
+It requires two serial ports, the example prints strings between the two ports.
 
 ### Hardware requirements
 
@@ -7,11 +8,11 @@ This code is part of a tutorial in which we demonstrate the basics of connecting
 
 ### Building and Running the Node
 ```bash
-$ cd HelloWorld 
+$ cd SerialConfig 
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ ./polysync-helloworld-cpp
+$ ./polysync-serial-config-cpp
 ```
 
 For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SerialReader/README.md
+++ b/SerialReader/README.md
@@ -1,0 +1,20 @@
+### SerialReader
+You would use this as a reference if you needed a node to listen to a device over a serial connection.
+This example creates and reads data through a serial connection, to a hardware device, or another software application.
+It exercises the Serial API.
+It pairs nicely with the `SerialWriter` example.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd SerialReader 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-serial-reader-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SerialReader/README.md
+++ b/SerialReader/README.md
@@ -1,21 +1,20 @@
 ### SerialReader
 
-You would use this as a reference if you needed a node to listen to a device over a serial connection.
-This example creates and reads data through a serial connection, to a hardware device, or another software application.
-It exercises the Serial API.
-It pairs nicely with the `SerialWriter` example.
+This can be used as a reference if a node is required to listen to a device over a serial connection.
+This example creates and reads data through a serial connection to a hardware device, or another software application.
+It exercises the Serial API and pairs nicely with the `SerialWriter` example.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SerialReader 
@@ -25,4 +24,4 @@ $ make
 $ ./polysync-serial-reader-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/SerialReader/README.md
+++ b/SerialReader/README.md
@@ -1,14 +1,22 @@
 ### SerialReader
+
 You would use this as a reference if you needed a node to listen to a device over a serial connection.
 This example creates and reads data through a serial connection, to a hardware device, or another software application.
 It exercises the Serial API.
 It pairs nicely with the `SerialWriter` example.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd SerialReader 
 $ mkdir build && cd build

--- a/SerialWriter/README.md
+++ b/SerialWriter/README.md
@@ -1,20 +1,20 @@
 ### SerialWriter
 
-You would use this as a reference if you needed a node to talk directly to a device over a serial connection.
+This can be used as a reference if a node is required to speak directly to a device over a serial connection.
 It pairs nicely with the `SerialReader` example.
-This example creates and writes data to a serial connection, to a hardware device, or another software application.
+This example creates and writes data to a serial connection, to a hardware device, or to another software application.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SerialWriter 
@@ -24,4 +24,4 @@ $ make
 $ ./polysync-serial-writer-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/SerialWriter/README.md
+++ b/SerialWriter/README.md
@@ -1,0 +1,19 @@
+### SerialWriter
+You would use this as a reference if you needed a node to talk directly to a device over a serial connection.
+It pairs nicely with the `SerialReader` example.
+This example creates and writes data to a serial connection, to a hardware device, or another software application.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd SerialWriter 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-serial-writer-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SerialWriter/README.md
+++ b/SerialWriter/README.md
@@ -1,13 +1,21 @@
 ### SerialWriter
+
 You would use this as a reference if you needed a node to talk directly to a device over a serial connection.
 It pairs nicely with the `SerialReader` example.
 This example creates and writes data to a serial connection, to a hardware device, or another software application.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd SerialWriter 
 $ mkdir build && cd build

--- a/SharedMemoryImageDataViewer/README.md
+++ b/SharedMemoryImageDataViewer/README.md
@@ -1,9 +1,9 @@
 ### SharedMemoryImageDataViewer
 
-This code is an example application that demonstrates using the PolySync Shared Memory C++ API to read, encode, decode, and view data placed in shared memory by a video device driver writing to shared memory using the PolySync Shared Memory API in C++.
+This code is an example application that demonstrates using the PolySync Shared Memory C++ API. This can be used to read, encode, decode, and view data placed in shared memory by a video device driver writing to shared memory using the PolySync Shared Memory API in C++.
 
 You must set up the shared memory queue buffer size prior to starting the application.
-It expects RGB24 pixel format.
+It requires RGB24 pixel format.
 
 ### Hardware requirements
 
@@ -13,18 +13,18 @@ Video Device
 ### Dependencies
 
 A system installation of Qt is required for this to compile.
-Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
-Download and install Qt [here](http://www.qt.io/download/)
+Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html). 
+Download and install Qt [here](http://www.qt.io/download/).
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ````
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SharedMemoryImageDataViewer 
@@ -34,4 +34,4 @@ $ make
 $ ./polysync-sharedmem-image-data-viewer-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/SharedMemoryImageDataViewer/README.md
+++ b/SharedMemoryImageDataViewer/README.md
@@ -1,9 +1,23 @@
-This code is an example application to demonstrates using the PolySync Shared Memory C++ API to read, encode, decode, and view data placed in shared memory by a video device driver writing to shared memory using the PolySync Shared Memory API in C++.
+### SharedMemoryImageDataViewer
+This code is an example application that demonstrates using the PolySync Shared Memory C++ API to read, encode, decode, and view data placed in shared memory by a video device driver writing to shared memory using the PolySync Shared Memory API in C++.
 
+You must set up the shared memory queue buffer size prior to starting the application.
+It expects RGB24 pixel format.
+
+### Hardware requirements
+
+### Dependencies
 A system installation of Qt is required for this to compile.
-
 Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
 Download and install Qt [here](http://www.qt.io/download/)
 
-For more examples and tutorials, visit the PolySync Knowledge Base [here](https://support.harbrick.com/hc/en-us/articles/216968458)
+### Building and Running the Node
+```bash
+$ cd SharedMemoryImageDataViewer 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-sharedmem-image-data-viewer-cpp
+```
 
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SharedMemoryImageDataViewer/README.md
+++ b/SharedMemoryImageDataViewer/README.md
@@ -1,4 +1,5 @@
 ### SharedMemoryImageDataViewer
+
 This code is an example application that demonstrates using the PolySync Shared Memory C++ API to read, encode, decode, and view data placed in shared memory by a video device driver writing to shared memory using the PolySync Shared Memory API in C++.
 
 You must set up the shared memory queue buffer size prior to starting the application.
@@ -6,12 +7,25 @@ It expects RGB24 pixel format.
 
 ### Hardware requirements
 
+Sensors: LiDAR, RADAR
+Video Device
+
 ### Dependencies
+
 A system installation of Qt is required for this to compile.
 Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
 Download and install Qt [here](http://www.qt.io/download/)
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+````
+
 ### Building and Running the Node
+
 ```bash
 $ cd SharedMemoryImageDataViewer 
 $ mkdir build && cd build

--- a/SingleTransform/README.md
+++ b/SingleTransform/README.md
@@ -1,19 +1,19 @@
 ### SingleTransform
 
 This example demonstrates PolySync transform API usage.
-It pushes a transform to the stack and then shows resulting transformation.
+It pushes a transform to the stack, and then shows the resulting transformation.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SingleTransform 
@@ -23,4 +23,4 @@ $ make
 $ ./polysync-single-transform-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).   

--- a/SingleTransform/README.md
+++ b/SingleTransform/README.md
@@ -1,0 +1,18 @@
+### SingleTransform
+This example demonstrates PolySync transform API usage.
+It pushes a transform to the stack and then shows resulting transformation.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd SingleTransform 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-single-transform-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SingleTransform/README.md
+++ b/SingleTransform/README.md
@@ -1,12 +1,20 @@
 ### SingleTransform
+
 This example demonstrates PolySync transform API usage.
 It pushes a transform to the stack and then shows resulting transformation.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd SingleTransform 
 $ mkdir build && cd build

--- a/SocketReader/README.md
+++ b/SocketReader/README.md
@@ -1,19 +1,19 @@
 ### SocketReader
 
-This is a simple example to show UDP socket communication in PolySync, using the PolySync socket API.
-It reads from UDP socket using API calls and socket class.
+This is a simple example illustrating UDP socket communication in PolySync when using the PolySync socket API.
+It reads from the UDP socket using API calls and socket class.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SocketReader 
@@ -23,4 +23,4 @@ $ make
 $ ./polysync-socket-reader-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/SocketReader/README.md
+++ b/SocketReader/README.md
@@ -1,0 +1,18 @@
+### SocketReader
+This is a simple example to show UDP socket communication in PolySync, using the PolySync socket API.
+It reads from UDP socket using API calls and socket class.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd SocketReader 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-socket-reader-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SocketReader/README.md
+++ b/SocketReader/README.md
@@ -1,12 +1,20 @@
 ### SocketReader
+
 This is a simple example to show UDP socket communication in PolySync, using the PolySync socket API.
 It reads from UDP socket using API calls and socket class.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd SocketReader 
 $ mkdir build && cd build

--- a/SocketWriter/README.md
+++ b/SocketWriter/README.md
@@ -1,0 +1,18 @@
+### SocketWriter
+This is a simple example to show UDP socket communication in PolySync, using the PolySync socket API
+It writes from UDP socket using API calls and socket class
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd SocketWriter 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-socket-writer-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/SocketWriter/README.md
+++ b/SocketWriter/README.md
@@ -1,12 +1,20 @@
 ### SocketWriter
+
 This is a simple example to show UDP socket communication in PolySync, using the PolySync socket API
 It writes from UDP socket using API calls and socket class
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd SocketWriter 
 $ mkdir build && cd build

--- a/SocketWriter/README.md
+++ b/SocketWriter/README.md
@@ -1,19 +1,19 @@
 ### SocketWriter
 
-This is a simple example to show UDP socket communication in PolySync, using the PolySync socket API
-It writes from UDP socket using API calls and socket class
+This is a simple example illustrating UDP socket communication in PolySync when using the PolySync socket API.
+It writes from UDP socket using API calls and socket class.
 
 ### Dependencies
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd SocketWriter 
@@ -23,4 +23,4 @@ $ make
 $ ./polysync-socket-writer-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/TransformStack/README.md
+++ b/TransformStack/README.md
@@ -1,6 +1,6 @@
 ### TransformStack
 
-This example shows how to use the transform API to perform multiple transforms in the same stack.
+This example illustrates how to use the transform API to perform multiple transforms in the same stack.
 It demonstrates PolySync transform API usage.
 It pushes a transform to the stack.
 

--- a/TransformStack/README.md
+++ b/TransformStack/README.md
@@ -1,13 +1,21 @@
 ### TransformStack
+
 This example shows how to use the transform API to perform multiple transforms in the same stack.
 It demonstrates PolySync transform API usage.
 It pushes a transform to the stack.
 
-### Hardware requirements
-
 ### Dependencies
 
+Packages: libglib2.0-dev
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd TransformStack 
 $ mkdir build && cd build

--- a/TransformStack/README.md
+++ b/TransformStack/README.md
@@ -8,13 +8,13 @@ It pushes a transform to the stack.
 
 Packages: libglib2.0-dev
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd TransformStack 
@@ -24,4 +24,4 @@ $ make
 $ ./polysync-transform-stack-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/TransformStack/README.md
+++ b/TransformStack/README.md
@@ -1,0 +1,19 @@
+### TransformStack
+This example shows how to use the transform API to perform multiple transforms in the same stack.
+It demonstrates PolySync transform API usage.
+It pushes a transform to the stack.
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd TransformStack 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-transform-stack-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/VideoDeviceViewer/README.md
+++ b/VideoDeviceViewer/README.md
@@ -1,9 +1,24 @@
+### VideoDeviceViewer
 This code is an example application to demonstrate interaction with a video device using the PolySync Video API in C++.
+It will visualize LiDAR, RADAR and object data from multiple sources.
+This example has tools to freeze-frame and measure distance; color by source or type; great for building sensor fusion applications.
+The graphics were built with OpenGL and are very extendable.
+It has a built in system/node management tool to dynamically handle nodes coming on/off bus.
 
+### Hardware requirements
+
+### Dependencies
 A system installation of Qt is required for this to compile.
-
 Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
 Download and install Qt [here](http://www.qt.io/download/)
 
-For more examples and tutorials, visit the PolySync Knowledge Base [here](https://support.harbrick.com/hc/en-us/articles/216968458)
+### Building and Running the Node
+```bash
+$ cd VideoDeviceViewer 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-video-device-viewer-cpp
+```
 
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)

--- a/VideoDeviceViewer/README.md
+++ b/VideoDeviceViewer/README.md
@@ -1,10 +1,10 @@
 ### VideoDeviceViewer
 
 This code is an example application to demonstrate interaction with a video device using the PolySync Video API in C++.
-It will visualize LiDAR, RADAR and object data from multiple sources.
-This example has tools to freeze-frame and measure distance; color by source or type; great for building sensor fusion applications.
+It will visualize LiDAR, RADAR, and object data from multiple sources.
+This example has tools to freeze frame and measure distance, color by source or type, and is great for building sensor fusion applications.
 The graphics were built with OpenGL and are very extendable.
-It has a built in system/node management tool to dynamically handle nodes coming on/off bus.
+It has a built-in system/node management tool to dynamically handle nodes coming on/off bus.
 
 ### Hardware requirements
 
@@ -14,18 +14,18 @@ Video Device
 ### Dependencies
 
 A system installation of Qt is required for this to compile.
-Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
-Download and install Qt [here](http://www.qt.io/download/)
+Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html). 
+Download and install Qt [here](http://www.qt.io/download/).
 
 Packages: libglib2.0-dev libgstreamer1.0-0
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd VideoDeviceViewer 
@@ -35,4 +35,4 @@ $ make
 $ ./polysync-video-device-viewer-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/VideoDeviceViewer/README.md
+++ b/VideoDeviceViewer/README.md
@@ -1,4 +1,5 @@
 ### VideoDeviceViewer
+
 This code is an example application to demonstrate interaction with a video device using the PolySync Video API in C++.
 It will visualize LiDAR, RADAR and object data from multiple sources.
 This example has tools to freeze-frame and measure distance; color by source or type; great for building sensor fusion applications.
@@ -7,12 +8,25 @@ It has a built in system/node management tool to dynamically handle nodes coming
 
 ### Hardware requirements
 
+Sensors: LiDAR, RADAR
+Video Device
+
 ### Dependencies
+
 A system installation of Qt is required for this to compile.
 Qt operates under [LGPLv3](http://www.gnu.org/licenses/lgpl-3.0.en.html) 
 Download and install Qt [here](http://www.qt.io/download/)
 
+Packages: libglib2.0-dev libgstreamer1.0-0
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd VideoDeviceViewer 
 $ mkdir build && cd build

--- a/VideoEncodeDecode/README.md
+++ b/VideoEncodeDecode/README.md
@@ -1,4 +1,5 @@
 ### VideoDeviceViewer
+
 This example demonstrates how to use the Video API routines to communicate with a video device, and encode/decode the data.
 
 You would use this example if you needed a node to talk directly to a video device, and didn’t want to use the `generic-video-device` driver, which supports all V4L USB video devices.
@@ -8,9 +9,21 @@ It expects XXXXX pixel format
 
 ### Hardware requirements
 
+Sensors: LiDAR, RADAR
+Video Device
+
 ### Dependencies
 
+Packages: libglib2.0-dev libgstreamer1.0-0
+
+To install on Ubuntu
+
+```bash
+sudo apt-get install <package>
+```
+
 ### Building and Running the Node
+
 ```bash
 $ cd VideoDeviceViewer 
 $ mkdir build && cd build

--- a/VideoEncodeDecode/README.md
+++ b/VideoEncodeDecode/README.md
@@ -16,13 +16,13 @@ Video Device
 
 Packages: libglib2.0-dev libgstreamer1.0-0
 
-To install on Ubuntu
+To install on Ubuntu:
 
 ```bash
 sudo apt-get install <package>
 ```
 
-### Building and Running the Node
+### Building and running the node
 
 ```bash
 $ cd VideoDeviceViewer 
@@ -32,4 +32,4 @@ $ make
 $ ./polysync-video-encode-decode-cpp
 ```
 
-For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)
+For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).

--- a/VideoEncodeDecode/README.md
+++ b/VideoEncodeDecode/README.md
@@ -1,2 +1,22 @@
-# PolySync Video API C++ example application
-Demonstrates how to use the Video API routines to communicate with a video device, and encode/decode the data.
+### VideoDeviceViewer
+This example demonstrates how to use the Video API routines to communicate with a video device, and encode/decode the data.
+
+You would use this example if you needed a node to talk directly to a video device, and didn’t want to use the `generic-video-device` driver, which supports all V4L USB video devices.
+It connects to a USB webcam (that must be Video4Linux (V4L) compatible), encodes the sensor data, and then decodes the same image stream to show the image processing pipeline.
+This DOES NOT connect to a node defined in the SDF, it connects directly to the hardware device using the Video API.
+It expects XXXXX pixel format
+
+### Hardware requirements
+
+### Dependencies
+
+### Building and Running the Node
+```bash
+$ cd VideoDeviceViewer 
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ ./polysync-video-encode-decode-cpp
+```
+
+For more API examples visit the "Turorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/)


### PR DESCRIPTION
Prior to this commit the README.md files did not exist or did not conform to the README template.  Added a description and build instructions.