### PR TITLE
Add polysync lidar translator example and README

### DIFF
--- a/PolysyncLidarTranslator/README.md
+++ b/PolysyncLidarTranslator/README.md
@@ -6,57 +6,78 @@ http://wiki.ros.org/catkin/Tutorials/create_a_workspace
 
 If you do have a workspace feel free to continue with the steps below. First source your ROS install and then create a package in the src directory of your catkin workspace as shown below.
 
-    $ cd ~/catkin_ws/src
-    $ source /opt/ros/indigo/setup.bash
-    $ catkin_create_pkg polysync_lidar_translator std_msgs roscpp tf
+```bash
+$ cd ~/catkin_ws/src
+$ source /opt/ros/indigo/setup.bash
+$ catkin_create_pkg polysync_lidar_translator std_msgs roscpp tf
+```
 
 Copy "polysync_lidar_translator_node.cpp" to the src directory of the polysync_lidar_translator package you created.
 
+```bash
     $ cp PolySync-Core-CPP-Examples/PolysyncLidarTranslator/polysync_lidar_translator_node.cpp ~/catkin_ws/src/polysync_lidar_translator/src/
+```
 
 Make sure that in the "Build" section of the CMakeLists file for your PolysyncLidarTranslator project are uncommented. All other lines in the "Build" section should be commented.
 
-    ## Declare a C++ executable
-    add_executable(polysync_lidar_translator_node src/polysync_lidar_translator_node.cpp)
+```bash
+## Declare a C++ executable
+add_executable(polysync_lidar_translator_node src/polysync_lidar_translator_node.cpp)
 
-    ## Add cmake target dependencies of the executable
-    ## same as for the library above
-    add_dependencies(polysync_lidar_translator_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+## Add cmake target dependencies of the executable
+## same as for the library above
+add_dependencies(polysync_lidar_translator_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-    ## Specify libraries to link a library or executable target against
-    target_link_libraries(polysync_lidar_translator_node
-       ${catkin_LIBRARIES}
-     )
+## Specify libraries to link a library or executable target against
+target_link_libraries(polysync_lidar_translator_node
+   ${catkin_LIBRARIES}
+ )
+```
 
 Generate the ros_bridge files in the src folder of your catkin workspace and copy the ros_bridge project into the root directory of your catkin workspace; as shown below.
 
-    $ cd ~/catkin_ws/src
-    $ pdm-gen -r /usr/local/polysync/modules/sensor/sensor.idl /usr/local/polysync/modules/navigation/navigation.idl /usr/local/polysync/modules/control/control.idl /usr/local/polysync/modules/dtc/dtc.idl
-    $ mv pdm/ros_bridge ../
-    $ rm -rf pdm
+```bash
+$ cd ~/catkin_ws/src
+$ pdm-gen -r /usr/local/polysync/modules/sensor/sensor.idl /usr/local/polysync/modules/navigation/navigation.idl /usr/local/polysync/modules/control/control.idl /usr/local/polysync/modules/dtc/dtc.idl
+$ mv pdm/ros_bridge ../
+$ rm -rf pdm
+```
 
 Source the ros_bridge, and then run catkin_make in the root directory of your catkin workspace.
 
-    $ cd ~/catkin_ws
-    $ source ros_bridge/setup.bash
-    $ catkin_make
+```bash
+$ cd ~/catkin_ws
+$ source ros_bridge/setup.bash
+$ catkin_make
+```
 
 Run ROS bridge node as shown below. (remember to source ros_bridge/setup.bash if using a different terminal)
 
-    $ cd ~/catkin_ws/ros_bridge/share/polysync_ros_bridge
-    $ ./BridgeNode -t ps_lidar_points_msg
+```bash
+$ cd ~/catkin_ws/ros_bridge/share/polysync_ros_bridge
+$ ./BridgeNode -t ps_lidar_points_msg
+```
 
 Start up PolySync data generator in another terminal.
 
-    $ polysync-data-generator-c
+```bash
+$ polysync-data-generator-c
+```
 
 Run the translator project you just built. The executable should be in the devel folder of your catkin workspace.
 
-    $ cd ~/catkin_ws/devel/lib/polysync_lidar_translator
-    $ ./polysync_lidar_translator_node
+```bash
+$ cd ~/catkin_ws/devel/lib/polysync_lidar_translator
+$ ./polysync_lidar_translator_node
+```
 
 Open up rviz.
 
-    $ rosrun rviz rviz
+```bash
+$ rosrun rviz rviz
+```
 
-In "Global Options" for the fixed frame select "world". Then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points". You can change the style to "Points" to have a little more realistic looking lidar point could.
+In "Global Options" for the fixed frame select "world". Then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points". You can change the style to "Points" to have a little more realistic looking lidar point cloud.
+
+
+This example is generalized to work with multiple Lidar drivers working in PolySync. Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in it's frame_id field. Thus you can differentiate the incoming data as neccessary. Similarly the PolySync timstamp is copied over to the native PointCloud2 messages. The transform for each incoming message of a particular GUID can be manually modified to match what is in the PolySync SDF. This allows simple sensor translation so that the data is correctly kept relative to the vehicles center frame, as in PolySync. Finally, with a little work this example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, thus allowing you to use all Radar drivers in PolySync with ROS. This example is intended to be very easy to use but very powerful in it's potential applications.

--- a/PolysyncLidarTranslator/README.md
+++ b/PolysyncLidarTranslator/README.md
@@ -6,57 +6,78 @@ http://wiki.ros.org/catkin/Tutorials/create_a_workspace
 
 If you do have a workspace feel free to continue with the steps below. First source your ROS install and then create a package in the src directory of your catkin workspace as shown below.
 
-    $ cd ~/catkin_ws/src
-    $ source /opt/ros/indigo/setup.bash
-    $ catkin_create_pkg polysync_lidar_translator std_msgs roscpp tf
+```bash
+$ cd ~/catkin_ws/src
+$ source /opt/ros/indigo/setup.bash
+$ catkin_create_pkg polysync_lidar_translator std_msgs roscpp tf
+```
 
 Copy "polysync_lidar_translator_node.cpp" to the src directory of the polysync_lidar_translator package you created.
 
+```bash
     $ cp PolySync-Core-CPP-Examples/PolysyncLidarTranslator/polysync_lidar_translator_node.cpp ~/catkin_ws/src/polysync_lidar_translator/src/
+```
 
 Make sure that in the "Build" section of the CMakeLists file for your PolysyncLidarTranslator project are uncommented. All other lines in the "Build" section should be commented.
 
-    ## Declare a C++ executable
-    add_executable(polysync_lidar_translator_node src/polysync_lidar_translator_node.cpp)
+```bash
+## Declare a C++ executable
+add_executable(polysync_lidar_translator_node src/polysync_lidar_translator_node.cpp)
 
-    ## Add cmake target dependencies of the executable
-    ## same as for the library above
-    add_dependencies(polysync_lidar_translator_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+## Add cmake target dependencies of the executable
+## same as for the library above
+add_dependencies(polysync_lidar_translator_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-    ## Specify libraries to link a library or executable target against
-    target_link_libraries(polysync_lidar_translator_node
-       ${catkin_LIBRARIES}
-     )
+## Specify libraries to link a library or executable target against
+target_link_libraries(polysync_lidar_translator_node
+   ${catkin_LIBRARIES}
+ )
+```
 
 Generate the ros_bridge files in the src folder of your catkin workspace and copy the ros_bridge project into the root directory of your catkin workspace; as shown below.
 
-    $ cd ~/catkin_ws/src
-    $ pdm-gen -r /usr/local/polysync/modules/sensor/sensor.idl /usr/local/polysync/modules/navigation/navigation.idl /usr/local/polysync/modules/control/control.idl /usr/local/polysync/modules/dtc/dtc.idl
-    $ mv pdm/ros_bridge ../
-    $ rm -rf pdm
+```bash
+$ cd ~/catkin_ws/src
+$ pdm-gen -r /usr/local/polysync/modules/sensor/sensor.idl /usr/local/polysync/modules/navigation/navigation.idl /usr/local/polysync/modules/control/control.idl /usr/local/polysync/modules/dtc/dtc.idl
+$ mv pdm/ros_bridge ../
+$ rm -rf pdm
+```
 
 Source the ros_bridge, and then run catkin_make in the root directory of your catkin workspace.
 
-    $ cd ~/catkin_ws
-    $ source ros_bridge/setup.bash
-    $ catkin_make
+```bash
+$ cd ~/catkin_ws
+$ source ros_bridge/setup.bash
+$ catkin_make
+```
 
 Run ROS bridge node as shown below. (remember to source ros_bridge/setup.bash if using a different terminal)
 
-    $ cd ~/catkin_ws/ros_bridge/share/polysync_ros_bridge
-    $ ./BridgeNode -t ps_lidar_points_msg
+```bash
+$ cd ~/catkin_ws/ros_bridge/share/polysync_ros_bridge
+$ ./BridgeNode -t ps_lidar_points_msg
+```
 
 Start up PolySync data generator in another terminal.
 
-    $ polysync-data-generator-c
+```bash
+$ polysync-data-generator-c
+```
 
 Run the translator project you just built. The executable should be in the devel folder of your catkin workspace.
 
-    $ cd ~/catkin_ws/devel/lib/polysync_lidar_translator
-    $ ./polysync_lidar_translator_node
+```bash
+$ cd ~/catkin_ws/devel/lib/polysync_lidar_translator
+$ ./polysync_lidar_translator_node
+```
 
 Open up rviz.
 
-    $ rosrun rviz rviz
+```bash
+$ rosrun rviz rviz
+```
 
-In "Global Options" for the fixed frame select "world". Then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points". You can change the style to "Points" to have a little more realistic looking lidar point could.
+In "Global Options" for the fixed frame select "world". Then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points". You can change the style to "Points" to have a little more realistic looking lidar point cloud.
+
+
+This example is generalized to work with multiple Lidar drivers working in PolySync. Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in it's frame_id field. Thus you can differentiate the incoming data as necessary. Similarly the PolySync timestamp is copied over to the native PointCloud2 messages. The transform for each incoming message of a particular GUID can be manually modified to match what is in the PolySync SDF. This allows simple sensor translation so that the data is correctly kept relative to the vehicles center frame, as in PolySync. Finally, with a little work this example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, thus allowing you to use all Radar drivers in PolySync with ROS. This example is intended to be very easy to use but very powerful in it's potential applications.

--- a/PolysyncLidarTranslator/README.md
+++ b/PolysyncLidarTranslator/README.md
@@ -1,0 +1,62 @@
+To properly build this example with the generated PolySync messages in ROS, you will first need to set up your catkin workspace with the ros_bridge.
+
+If you do not have a catkin workspace already, follow these steps to set one up.
+
+http://wiki.ros.org/catkin/Tutorials/create_a_workspace
+
+If you do have a workspace feel free to continue with the steps below. First source your ROS install and then create a package in the src directory of your catkin workspace as shown below.
+
+    $ cd ~/catkin_ws/src
+    $ source /opt/ros/indigo/setup.bash
+    $ catkin_create_pkg polysync_lidar_translator std_msgs roscpp tf
+
+Copy "polysync_lidar_translator_node.cpp" to the src directory of the polysync_lidar_translator package you created.
+
+    $ cp PolySync-Core-CPP-Examples/PolysyncLidarTranslator/polysync_lidar_translator_node.cpp ~/catkin_ws/src/polysync_lidar_translator/src/
+
+Make sure that in the "Build" section of the CMakeLists file for your PolysyncLidarTranslator project are uncommented. All other lines in the "Build" section should be commented.
+
+    ## Declare a C++ executable
+    add_executable(polysync_lidar_translator_node src/polysync_lidar_translator_node.cpp)
+
+    ## Add cmake target dependencies of the executable
+    ## same as for the library above
+    add_dependencies(polysync_lidar_translator_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+    ## Specify libraries to link a library or executable target against
+    target_link_libraries(polysync_lidar_translator_node
+       ${catkin_LIBRARIES}
+     )
+
+Generate the ros_bridge files in the src folder of your catkin workspace and copy the ros_bridge project into the root directory of your catkin workspace; as shown below.
+
+    $ cd ~/catkin_ws/src
+    $ pdm-gen -r /usr/local/polysync/modules/sensor/sensor.idl /usr/local/polysync/modules/navigation/navigation.idl /usr/local/polysync/modules/control/control.idl /usr/local/polysync/modules/dtc/dtc.idl
+    $ mv pdm/ros_bridge ../
+    $ rm -rf pdm
+
+Source the ros_bridge, and then run catkin_make in the root directory of your catkin workspace.
+
+    $ cd ~/catkin_ws
+    $ source ros_bridge/setup.bash
+    $ catkin_make
+
+Run ROS bridge node as shown below. (remember to source ros_bridge/setup.bash if using a different terminal)
+
+    $ cd ~/catkin_ws/ros_bridge/share/polysync_ros_bridge
+    $ ./BridgeNode -t ps_lidar_points_msg
+
+Start up PolySync data generator in another terminal.
+
+    $ polysync-data-generator-c
+
+Run the translator project you just built. The executable should be in the devel folder of your catkin workspace.
+
+    $ cd ~/catkin_ws/devel/lib/polysync_lidar_translator
+    $ ./polysync_lidar_translator_node
+
+Open up rviz.
+
+    $ rosrun rviz rviz
+
+In "Global Options" for the fixed frame select "world". Then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points". You can change the style to "Points" to have a little more realistic looking lidar point could.

--- a/PolysyncLidarTranslator/README.md
+++ b/PolysyncLidarTranslator/README.md
@@ -1,3 +1,5 @@
+This example is a generalized Lidar message translator for messages coming from PolySync into ROS via the PolySync ROS bridge. It is generalized to work with any Lidar driver or application running in PolySync. Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in it's frame_id field. Thus you can differentiate the incoming data as necessary. Similarly the PolySync timestamp is copied over to the native PointCloud2 messages. The transform for each incoming message of a particular GUID can be manually modified to match what is in the PolySync SDF. This allows simple sensor translation so that the data is correctly kept relative to the vehicles center frame, as in PolySync. It would be easy to adapt this example to publish in the other direction if necessary. Finally, with a little work this example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, thus allowing you to use all Radar drivers in PolySync with ROS. This example is intended to be very easy to use but very powerful in it's potential applications.
+
 To properly build this example with the generated PolySync messages in ROS, you will first need to set up your catkin workspace with the ros_bridge.
 
 If you do not have a catkin workspace already, follow these steps to set one up.
@@ -78,6 +80,3 @@ $ rosrun rviz rviz
 ```
 
 In "Global Options" for the fixed frame select "world". Then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points". You can change the style to "Points" to have a little more realistic looking lidar point cloud.
-
-
-This example is generalized to work with multiple Lidar drivers working in PolySync. Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in it's frame_id field. Thus you can differentiate the incoming data as necessary. Similarly the PolySync timestamp is copied over to the native PointCloud2 messages. The transform for each incoming message of a particular GUID can be manually modified to match what is in the PolySync SDF. This allows simple sensor translation so that the data is correctly kept relative to the vehicles center frame, as in PolySync. Finally, with a little work this example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, thus allowing you to use all Radar drivers in PolySync with ROS. This example is intended to be very easy to use but very powerful in it's potential applications.

--- a/PolysyncLidarTranslator/README.md
+++ b/PolysyncLidarTranslator/README.md
@@ -1,14 +1,14 @@
-## Lidar Translator
+## LiDAR Translator
 
-This example is a generalized Lidar message translator for messages coming from PolySync into ROS via the PolySync ROS bridge. It is generalized to work with any Lidar driver or application running in PolySync. 
+This example is a generalized LiDAR message translator for messages coming from PolySync into ROS via the PolySync ROS bridge. It is generalized to work with any LiDAR driver or application running in PolySync. 
 
-Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in it's frame_id field. Thus you can differentiate the incoming data as necessary. Similarly the PolySync timestamp is copied over to the native PointCloud2 messages. 
+Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in its frame_id field. Thus, you can differentiate the incoming data as necessary. Similarly, the PolySync timestamp is copied over to the native PointCloud2 messages. 
 
 The transform for each incoming message of a particular GUID can be manually modified to match what is in the PolySync SDF. This allows simple sensor translation so that the data is correctly kept relative to the vehicles center frame, as in PolySync. 
 
-It would be easy to adapt this example to publish data in the other direction. This example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, allowing you to use all RADAR drivers in PolySync with ROS. This example is intended to be very easy to use but very powerful in it's potential applications.
+It would be easy to adapt this example to publish data in the other direction. This example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, allowing you to use all RADAR drivers in PolySync with ROS. This example is intended to be very easy to use while still being powerful in its potential applications.
 
-### Building and Running the Example
+### Building and running the example
 
 To properly build this example with the generated PolySync messages in ROS, you will first need to set up your catkin workspace with the ros_bridge.
 
@@ -16,7 +16,7 @@ If you do not have a catkin workspace already, follow these steps to set one up.
 
 http://wiki.ros.org/catkin/Tutorials/create_a_workspace
 
-If you do have a workspace feel free to continue with the steps below. First source your ROS install and then create a package in the src directory of your catkin workspace as shown below.
+If you do have a workspace, feel free to continue with the steps below. First source your ROS install, and then create a package in the src directory of your catkin workspace, as shown below.
 
 ```bash
 $ cd ~/catkin_ws/src
@@ -46,7 +46,7 @@ target_link_libraries(polysync_lidar_translator_node
  )
 ```
 
-Generate the ros_bridge files in the src folder of your catkin workspace and copy the ros_bridge project into the root directory of your catkin workspace; as shown below.
+Generate the ros_bridge files in the src folder of your catkin workspace, and copy the ros_bridge project into the root directory of your catkin workspace, as shown below.
 
 ```bash
 $ cd ~/catkin_ws/src
@@ -63,7 +63,7 @@ $ source ros_bridge/setup.bash
 $ catkin_make
 ```
 
-Run ROS bridge node as shown below. (remember to source ros_bridge/setup.bash if using a different terminal)
+Run ROS bridge node as shown below, remembering to source ros_bridge/setup.bash if using a different terminal.
 
 ```bash
 $ cd ~/catkin_ws/ros_bridge/share/polysync_ros_bridge
@@ -89,4 +89,4 @@ Open up rviz.
 $ rosrun rviz rviz
 ```
 
-In "Global Options" for the fixed frame select "world". Then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points". You can change the style to "Points" to have a little more realistic looking lidar point cloud.
+In "Global Options" for the fixed frame select "world," then hit "add" and add a new "PointCloud2" visualization. For the topic of this new visualization select "/polysync/lidar_points." You can change the style to "Points" to have a little more realistic looking LiDAR point cloud.

--- a/PolysyncLidarTranslator/README.md
+++ b/PolysyncLidarTranslator/README.md
@@ -1,4 +1,14 @@
-This example is a generalized Lidar message translator for messages coming from PolySync into ROS via the PolySync ROS bridge. It is generalized to work with any Lidar driver or application running in PolySync. Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in it's frame_id field. Thus you can differentiate the incoming data as necessary. Similarly the PolySync timestamp is copied over to the native PointCloud2 messages. The transform for each incoming message of a particular GUID can be manually modified to match what is in the PolySync SDF. This allows simple sensor translation so that the data is correctly kept relative to the vehicles center frame, as in PolySync. It would be easy to adapt this example to publish in the other direction if necessary. Finally, with a little work this example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, thus allowing you to use all Radar drivers in PolySync with ROS. This example is intended to be very easy to use but very powerful in it's potential applications.
+## Lidar Translator
+
+This example is a generalized Lidar message translator for messages coming from PolySync into ROS via the PolySync ROS bridge. It is generalized to work with any Lidar driver or application running in PolySync. 
+
+Each PointCloud2 message will contain the source GUID of the driver sending the `ps_lidar_points_msg` in it's frame_id field. Thus you can differentiate the incoming data as necessary. Similarly the PolySync timestamp is copied over to the native PointCloud2 messages. 
+
+The transform for each incoming message of a particular GUID can be manually modified to match what is in the PolySync SDF. This allows simple sensor translation so that the data is correctly kept relative to the vehicles center frame, as in PolySync. 
+
+It would be easy to adapt this example to publish data in the other direction. This example could be adapted to republish `ps_radar_targets_msg` to PointCloud2, allowing you to use all RADAR drivers in PolySync with ROS. This example is intended to be very easy to use but very powerful in it's potential applications.
+
+### Building and Running the Example
 
 To properly build this example with the generated PolySync messages in ROS, you will first need to set up your catkin workspace with the ros_bridge.
 

--- a/PolysyncLidarTranslator/polysync_lidar_translator_node.cpp
+++ b/PolysyncLidarTranslator/polysync_lidar_translator_node.cpp
@@ -62,7 +62,7 @@ void publishLidarTransform(
 }
 
 
-// CallBack for PolySync Lidar Targets
+// CallBack for PolySync Lidar Points
 void lidarCallback(
         const polysync_ros_bridge::ps_lidar_points_msg::ConstPtr& msg,
         ros::Publisher * lidar_pub )
@@ -77,7 +77,7 @@ void lidarCallback(
     std::string src_guid = src_guid_ss.str();
 
     // get PS timestamp in nanoseconds
-    long long ps_nanoseconds = msg->ps_header.timestamp*1000;
+    unsigned long long ps_nanoseconds = msg->ps_header.timestamp*1000;
 
     //Consistant timestamp for all lidar points in this single message
     uint headerSize = sizeof( msg->points[0].header );

--- a/PolysyncLidarTranslator/polysync_lidar_translator_node.cpp
+++ b/PolysyncLidarTranslator/polysync_lidar_translator_node.cpp
@@ -1,0 +1,177 @@
+#include <ros/ros.h>
+#include <tf/transform_broadcaster.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/PointField.h>
+#include <polysync_ros_bridge/ps_lidar_points_msg.h>
+
+
+using namespace sensor_msgs;
+
+
+
+
+//
+void addFieldToPointCloud(
+        PointCloud2 * cloud,
+        std::string name,
+        int offset,
+        int dataType,
+        int count )
+{
+    PointField field;
+
+    field.name = name;
+
+    field.offset = offset;
+
+    field.datatype = dataType;
+
+    field.count = count;
+
+    cloud->fields.push_back( field );
+}
+
+
+//
+void publishLidarTransform(
+        std::string frame_id,
+        double x,
+        double y,
+        double z,
+        double roll,
+        double pitch,
+        double yaw )
+{
+    static tf::TransformBroadcaster br;
+
+    tf::Transform transform;
+
+    transform.setOrigin( tf::Vector3( x, y, z ) );
+
+    tf::Quaternion q;
+
+    q.setRPY( roll, pitch, yaw );
+
+    transform.setRotation(q);
+
+    br.sendTransform( tf::StampedTransform(
+            transform,
+            ros::Time::now(),
+            "world",
+            frame_id ) );
+}
+
+
+// CallBack for PolySync Lidar Targets
+void lidarCallback(
+        const polysync_ros_bridge::ps_lidar_points_msg::ConstPtr& msg,
+        ros::Publisher * lidar_pub )
+{
+    PointCloud2 cloud;
+
+    ros::Time timer;
+
+    // Get the source GUID as a string
+    std::ostringstream src_guid_ss;
+    src_guid_ss << msg->ps_header.src_guid;
+    std::string src_guid = src_guid_ss.str();
+
+    // get PS timestamp in nanoseconds
+    long long ps_nanoseconds = msg->ps_header.timestamp*1000;
+
+    //Consistant timestamp for all lidar points in this single message
+    uint headerSize = sizeof( msg->points[0].header );
+    uint dataPointSize = sizeof( msg->points[0] ) - headerSize;
+    uint pointSize = sizeof(msg->points[0].position) / 3;
+
+    uint dataPointsSize = msg->points.size() * ( headerSize + dataPointSize );
+
+    cloud.header.frame_id = src_guid;
+    cloud.header.stamp = timer.fromNSec( ps_nanoseconds );
+
+    cloud.is_bigendian = false;
+    cloud.is_dense = true;
+
+    cloud.height = 1;
+
+    // number of points in message
+    cloud.width = msg->points.size();
+
+    cloud.point_step = headerSize + dataPointSize;
+    cloud.row_step = dataPointsSize;
+
+
+    addFieldToPointCloud(
+            &cloud,
+            "x",
+            headerSize,
+            PointField::FLOAT32,
+            msg->points.size() );
+
+    addFieldToPointCloud(
+            &cloud,
+            "y",
+            headerSize + pointSize*1,
+            PointField::FLOAT32,
+            msg->points.size() );
+
+    addFieldToPointCloud(
+            &cloud,
+            "z",
+            headerSize + pointSize*2,
+            PointField::FLOAT32,
+            msg->points.size() );
+
+    // intensity
+    addFieldToPointCloud(
+            &cloud,
+            "i",
+            headerSize + pointSize*3,
+            PointField::UINT8,
+            msg->points.size() );
+
+    cloud.data.resize( dataPointsSize );
+
+    std::memcpy(
+            cloud.data.data(),
+            msg->points.data(),
+            dataPointsSize );
+
+    //Publish array of markers as a single message
+    lidar_pub->publish( cloud );
+
+    // TODO : get transform values from PolySync SDF, for a specific GUID, and
+    // load them in here
+    publishLidarTransform( src_guid, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 );
+}
+
+
+
+
+//
+int main( int argc, char** argv )
+{
+    ros::init( argc, argv, "polysync_lidar_translator" );
+
+    ros::NodeHandle rosnode;
+
+    ros::Publisher lidar_pub;
+
+    ros::Subscriber lidar_sub;
+
+    lidar_pub =
+            rosnode.advertise < sensor_msgs::PointCloud2 >
+                    ( "polysync/lidar_points",
+                    1 );
+
+    lidar_sub =
+            rosnode.subscribe < polysync_ros_bridge::ps_lidar_points_msg >
+                    ( "polysync/ps_lidar_points_msg",
+                    1000,
+                    boost::bind( lidarCallback, _1, &lidar_pub ) );
+
+    ros::spin();
+
+    return 0;
+
+}


### PR DESCRIPTION
Prior to this commit the PolySync C++ examples did not include anything that showed users how to use PolySync to ROS bridge headers to compile a project with custom PolySync message types in ROS. This commit adds an example which compiles from the generated ROS bridge headers and re-publishes custom PolySync lidar messages as the native ROS PointCloud2 message type. This commit also adds a README which explains how to compile and use the example.