### PR TITLE
Rmove 'make install' target

### DIFF
--- a/CANReader/CMakeLists.txt
+++ b/CANReader/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable(
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/CANReaderAndPublisher/CMakeLists.txt
+++ b/CANReaderAndPublisher/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable(
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/CANWriter/CMakeLists.txt
+++ b/CANWriter/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable(
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-    )

--- a/CSVExporter/CMakeLists.txt
+++ b/CSVExporter/CMakeLists.txt
@@ -27,8 +27,3 @@ target_link_libraries( ${PROJECT_NAME}
     getopt_cpp 
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/DataGenerator/CMakeLists.txt
+++ b/DataGenerator/CMakeLists.txt
@@ -25,8 +25,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-    )

--- a/Echo/CMakeLists.txt
+++ b/Echo/CMakeLists.txt
@@ -33,8 +33,3 @@ target_link_libraries(
     polysync_cpp_message_support
     polysync_data_model
     )
-
-install(
-    TARGETS polysync-echo
-    DESTINATION ${PSYNC_HOME}/bin
-)

--- a/FileTransfer/CMakeLists.txt
+++ b/FileTransfer/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/GroundPlaneDetection/CMakeLists.txt
+++ b/GroundPlaneDetection/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/HelloWorld/CMakeLists.txt
+++ b/HelloWorld/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/HelloWorldPublisher/CMakeLists.txt
+++ b/HelloWorldPublisher/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/HelloWorldSubscriber/CMakeLists.txt
+++ b/HelloWorldSubscriber/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/LogSessionExport/CMakeLists.txt
+++ b/LogSessionExport/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/LogSessionImport/CMakeLists.txt
+++ b/LogSessionImport/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/LogfileIterator/CMakeLists.txt
+++ b/LogfileIterator/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/LogfileQueueReader/CMakeLists.txt
+++ b/LogfileQueueReader/CMakeLists.txt
@@ -30,9 +30,3 @@ target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
     glib-2.0
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)
-

--- a/LogfileReader/CMakeLists.txt
+++ b/LogfileReader/CMakeLists.txt
@@ -27,9 +27,3 @@ target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
     glib-2.0
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)
-

--- a/LogfileWriter/CMakeLists.txt
+++ b/LogfileWriter/CMakeLists.txt
@@ -22,8 +22,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/ParameterGetSet/CMakeLists.txt
+++ b/ParameterGetSet/CMakeLists.txt
@@ -42,7 +42,3 @@ target_link_libraries(
     polysync_data_model
 )
 
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/PathPlanner/CMakeLists.txt
+++ b/PathPlanner/CMakeLists.txt
@@ -44,8 +44,3 @@ target_link_libraries( polysync-path-planner-robot-cpp
     ${PSYNC_LIBS}
     ${OpenCV_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/PublishSubscribe/CMakeLists.txt
+++ b/PublishSubscribe/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/PublishSubscribe/Publish/CMakeLists.txt
+++ b/PublishSubscribe/Publish/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/PublishSubscribe/Subscribe/CMakeLists.txt
+++ b/PublishSubscribe/Subscribe/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/QtImageViewer/CMakeLists.txt
+++ b/QtImageViewer/CMakeLists.txt
@@ -31,8 +31,3 @@ target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
     Qt5::Widgets
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/Record/CMakeLists.txt
+++ b/Record/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/Replay/CMakeLists.txt
+++ b/Replay/CMakeLists.txt
@@ -24,8 +24,3 @@ add_executable(
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SampleApplication/CMakeLists.txt
+++ b/SampleApplication/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SerialConfig/CMakeLists.txt
+++ b/SerialConfig/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SerialReader/CMakeLists.txt
+++ b/SerialReader/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SerialWriter/CMakeLists.txt
+++ b/SerialWriter/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SharedMemoryImageDataViewer/CMakeLists.txt
+++ b/SharedMemoryImageDataViewer/CMakeLists.txt
@@ -31,8 +31,3 @@ target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
     Qt5::Widgets
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SingleTransform/CMakeLists.txt
+++ b/SingleTransform/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SocketReader/CMakeLists.txt
+++ b/SocketReader/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/SocketWriter/CMakeLists.txt
+++ b/SocketWriter/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/TransformStack/CMakeLists.txt
+++ b/TransformStack/CMakeLists.txt
@@ -23,8 +23,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/VideoDeviceViewer/CMakeLists.txt
+++ b/VideoDeviceViewer/CMakeLists.txt
@@ -31,8 +31,3 @@ target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
     Qt5::Widgets
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)

--- a/VideoEncodeDecode/CMakeLists.txt
+++ b/VideoEncodeDecode/CMakeLists.txt
@@ -22,8 +22,3 @@ add_executable( ${PROJECT_NAME}
 target_link_libraries( ${PROJECT_NAME}
     ${PSYNC_LIBS}
 )
-
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${PSYNC_HOME}/bin
-)


### PR DESCRIPTION
Prior to this commit, the Makefiles had an 'install' target which would
attempt to install their binaries into $PSYNC_HOME/bin, which is owned
by root:root and should not be polluted with examples. This commit
removes those install targets.