### PR TITLE
Use Message::getHeaderTimestamp()

### DIFF
--- a/DataGenerator/ObjectGenerator.cpp
+++ b/DataGenerator/ObjectGenerator.cpp
@@ -65,7 +65,7 @@ void ObjectGenerator::updateObjects()
     for( auto index = 0; index < _objectCount; ++index )
     {
         // Get time difference from last update
-        auto timeDelta = time - _message.getTimestamp();
+        auto timeDelta = time - _message.getHeaderTimestamp();
 
         // Convert to seconds
         auto timeDeltaSeconds = static_cast< double >( timeDelta )/ 1000000.0;

--- a/DataGenerator/RadarTargetGenerator.cpp
+++ b/DataGenerator/RadarTargetGenerator.cpp
@@ -65,7 +65,7 @@ void RadarTargetGenerator::updateTargets()
     for( auto index = 0; index < _targetsCount; ++index )
     {
         // Get time difference from last update
-        auto timeDelta = time - _message.getTimestamp();
+        auto timeDelta = time - _message.getHeaderTimestamp();
 
         // Convert to seconds
         auto timeDeltaSeconds = static_cast< double >( timeDelta )/ 1000000.0;


### PR DESCRIPTION
Prior commit was using Message::getTimestamp(), which has been deprecated.
The prefered method is Message::getHeaderTimestamp(). This  commit updates
the DataGenerator example to use the correct function.