### PR TITLE
Fix missing flag to pdm-gen

### DIFF
--- a/PolysyncLidarTranslator/README.md
+++ b/PolysyncLidarTranslator/README.md
@@ -50,7 +50,7 @@ Generate the ros_bridge files in the src folder of your catkin workspace, and co
 
 ```bash
 $ cd ~/catkin_ws/src
-$ pdm-gen -r /usr/local/polysync/modules/sensor/sensor.idl /usr/local/polysync/modules/navigation/navigation.idl /usr/local/polysync/modules/control/control.idl /usr/local/polysync/modules/dtc/dtc.idl
+$ pdm-gen -r -c /usr/local/polysync/modules/sensor/sensor.idl /usr/local/polysync/modules/navigation/navigation.idl /usr/local/polysync/modules/control/control.idl /usr/local/polysync/modules/dtc/dtc.idl
 $ mv pdm/ros_bridge ../
 $ rm -rf pdm
 ```


### PR DESCRIPTION
Prior to this commit the instructions for compiling the ROS bridge were missing a flag necessary to compile properly in all environments. This commit adds the correct flag.