### PR TITLE
fix/PathPlanner-deprecated-calls

### DIFF
--- a/PathPlanner/RobotNode.cpp
+++ b/PathPlanner/RobotNode.cpp
@@ -181,7 +181,7 @@ void RobotNode::messageEvent( std::shared_ptr< polysync::Message > newMsg )
 
     // check whether new message is not your own. This check is only important
     // since robotNode and searchNode both publish and subscribe to messages.
-    if ( newMsg->getSourceGuid( ) == getGuid( ) )
+    if ( newMsg->getHeaderSrcGuid( ) == getGuid( ) )
     {
         return;
     }
@@ -242,7 +242,7 @@ void RobotNode::sendLocationToPlanner( )
     msg.setHeaderTimestamp( polysync::getTimestamp() );
 
     // Populate buffer
-    msg.setPosition( { _waypointCounter, 0, 0 } );
+    msg.setPosition( { double( _waypointCounter ), 0, 0 } );
     msg.setOrientation( { actualRobLocX, actualRobLocY, 0, 0 } );
 
     // Publish to the PolySync bus

--- a/PathPlanner/SearchNode.cpp
+++ b/PathPlanner/SearchNode.cpp
@@ -201,7 +201,7 @@ void SearchNode::messageEvent( std::shared_ptr< polysync::Message > newMsg )
 
     // check whether new message is not your own. This check is only important
     // since robotNode and searchNode both publish and subscribe to messages.
-    if ( newMsg->getSourceGuid( ) == getGuid( ) )
+    if ( newMsg->getHeaderSrcGuid( ) == getGuid( ) )
     {
         return;
     }
@@ -273,8 +273,8 @@ void SearchNode::sendNextWaypoint( int newIndex, int waypointID )
     msg.setHeaderTimestamp( polysync::getTimestamp() );
 
     // Populate buffer
-    msg.setPosition( { double(waypointID), 0, double(_numWaypoints) } );
-    msg.setOrientation( { _newRobLocX, _newRobLocY, 0, 0 } );
+    msg.setPosition( { double( waypointID ), 0, double( _numWaypoints ) } );
+    msg.setOrientation( { double(_newRobLocX), double(_newRobLocY), 0, 0 } );
 
     // Publish to the PolySync bus
     msg.publish();


### PR DESCRIPTION
Prior to this pull request, the `PathPlanner` C++ example had a deprecated function call which hindered performance.  This commit corrects those callouts and also removes a narrowing warning when building.