### PR TITLE
Update example to use polysync::VideoDecoder.

### DIFF
--- a/QtImageViewer/VideoProcessor.cpp
+++ b/QtImageViewer/VideoProcessor.cpp
@@ -1,20 +1,73 @@
 #include "VideoProcessor.hpp"
 
-#include <PolySyncVideo.hpp>
-#include <PolySyncDTCException.hpp>
-
 #include <QImage>
-#include <QPixmap>
-#include <iostream>
 
-using namespace std;
+
+VideoProcessor::VideoProcessor()
+    :
+    decoder( { PIXEL_FORMAT_MJPEG, 320, 240, 30 },
+             { PIXEL_FORMAT_RGB24, 320, 240, 30 } )
+{}
+
 
 VideoProcessor::~VideoProcessor()
 {
     disconnectPolySync();
 }
 
+
 void VideoProcessor::slotRun()
 {
     connectPolySync();
+}
+
+
+void VideoProcessor::initStateEvent()
+{
+    // Register as a listener for the message type that the publisher
+    // is going to send.  Message types are defined in later tutorials.
+    registerListener( getMessageTypeByName( "ps_image_data_msg" ) );
+}
+
+
+void VideoProcessor::messageEvent(
+        std::shared_ptr< polysync::Message > message )
+{
+    using namespace polysync::datamodel;
+    if( auto incomingMessage = getSubclass< ImageDataMessage >( message ) )
+    {
+        if( incomingMessage->getPixelFormat() == PIXEL_FORMAT_MJPEG )
+        {
+            auto buffer = decodeBuffer( incomingMessage->getDataBuffer() );
+            if( buffer.size() > 0 )
+            {
+                auto image = buildQImageFromFrameBuffer( buffer );
+                if( not image.isNull() )
+                {
+                    emit signalPixmap( QPixmap::fromImage( image ) );
+                }
+            }
+        }
+        else
+        {
+            std::cout << "Warning: unsupported pixel format type; "
+                         "this image data is not viewable\n";
+        }
+
+    }
+}
+
+
+std::vector< uchar > VideoProcessor::decodeBuffer(
+        const std::vector<uchar> & buffer )
+{
+    decoder.decode( buffer );
+
+    return decoder.getCopyOfDecodedBuffer();
+}
+
+
+QImage VideoProcessor::buildQImageFromFrameBuffer( const std::vector< uchar > & buffer )
+{
+    return QImage{ buffer.data(), 320, 240, QImage::Format_RGB888 };
 }

--- a/QtImageViewer/VideoProcessor.cpp
+++ b/QtImageViewer/VideoProcessor.cpp
@@ -5,14 +5,23 @@
 
 VideoProcessor::VideoProcessor()
     :
-    decoder( { PIXEL_FORMAT_MJPEG, 320, 240, 30 },
-             { PIXEL_FORMAT_RGB24, 320, 240, 30 } )
-{}
+    decoder( { PIXEL_FORMAT_MJPEG, IMAGE_WIDTH, IMAGE_HEIGHT, FRAME_RATE },
+             { PIXEL_FORMAT_RGB24, IMAGE_WIDTH, IMAGE_HEIGHT, FRAME_RATE } ),
+    thread()
+{
+    moveToThread( &thread );
+
+    thread.start();
+}
 
 
 VideoProcessor::~VideoProcessor()
 {
     disconnectPolySync();
+
+    thread.quit();
+
+    thread.wait();
 }
 
 
@@ -24,8 +33,6 @@ void VideoProcessor::slotRun()
 
 void VideoProcessor::initStateEvent()
 {
-    // Register as a listener for the message type that the publisher
-    // is going to send.  Message types are defined in later tutorials.
     registerListener( getMessageTypeByName( "ps_image_data_msg" ) );
 }
 
@@ -67,7 +74,9 @@ std::vector< uchar > VideoProcessor::decodeBuffer(
 }
 
 
-QImage VideoProcessor::buildQImageFromFrameBuffer( const std::vector< uchar > & buffer )
+QImage VideoProcessor::buildQImageFromFrameBuffer(
+        const std::vector< uchar > & buffer )
 {
-    return QImage{ buffer.data(), 320, 240, QImage::Format_RGB888 };
+    return QImage{
+        buffer.data(), IMAGE_WIDTH, IMAGE_HEIGHT, QImage::Format_RGB888 };
 }

--- a/QtImageViewer/VideoProcessor.hpp
+++ b/QtImageViewer/VideoProcessor.hpp
@@ -3,14 +3,12 @@
 
 #include <PolySyncNode.hpp>
 #include <PolySyncDataModel.hpp>
-#include <PolySyncVideo.hpp>
 #include <PolySyncDTCException.hpp>
+#include <PolySyncVideo.hpp>
 
 #include <QObject>
-#include <QImage>
 #include <QPixmap>
 
-using namespace std;
 
 /**
  * @brief The VideoProcessor class
@@ -18,7 +16,7 @@ using namespace std;
  * messages.
  * This class connects to the PolySync bus, and subscribes to the ImageDataMessage
  * (ps_image_data_msg)
- * For each image received, a signal is emitted to the Pixmap.
+ * For each image received, a signal is emitted to the VideoViewer to render.
  */
 class VideoProcessor : public QObject, public polysync::Node
 {
@@ -27,63 +25,48 @@ class VideoProcessor : public QObject, public polysync::Node
 
 public:
 
+    VideoProcessor();
 
     ~VideoProcessor();
 
-    void initStateEvent() override
-        {
-            auto messageType = getMessageTypeByName( "ps_image_data_msg" );
+    void initStateEvent() override;
 
-            // Register as a listener for the message type that the publisher
-            // is going to send.  Message types are defined in later tutorials.
-            registerListener( messageType );
-        }
-
-        /**
-         * @brief messageEvent
-         *
-         * Extract the information from the provided message
-         *
-         * @param std::shared_ptr< Message > - variable containing the message
-         */
-        virtual void messageEvent( shared_ptr< polysync::Message > message )
-        {
-            using namespace polysync::datamodel;
-            if( shared_ptr< ImageDataMessage > incomingMessage = getSubclass< ImageDataMessage >( message ) )
-            {
-
-                if( incomingMessage->getPixelFormat() != PIXEL_FORMAT_MJPEG )
-                {
-                    cout << "Warning: unsupported pixel format type; this image data is not viewable" << endl;
-                }
-
-                auto buffer = incomingMessage->getDataBuffer();
-
-                emit signalPixmap( QPixmap::fromImage(
-                                       QImage::fromData(
-                                           buffer.data(), // get the C-style pointer
-                                           buffer.size() ) ) );
-            }
-        }
+    /**
+     * Extract the information from the provided message
+     *
+     * @param std::shared_ptr< Message > - variable containing the message
+     */
+    void messageEvent( std::shared_ptr< polysync::Message > message ) override;
 
 
 public slots:
 
     /**
-     * @brief slotRun
      * Contains the busy loop which polls for image data, packages
      * the data into a QPixmap, and sends to the VideoViewer object for
      * rendering.
      */
     void slotRun();
 
+
 signals:
 
     /**
-     * @brief signalPixmap
      * Qt Signal emitted when new data is ready for rendering. This triggers
      * @ref VideoViewer::slotUpdatePixmap, passing the new QPixmap to draw.
      */
     void signalPixmap( const QPixmap & );
+
+
+private:
+
+    QImage buildQImageFromFrameBuffer( const std::vector< uchar > & buffer );
+
+    std::vector< uchar > decodeBuffer(
+            const std::vector< uchar > & buffer );
+
+    polysync::VideoDecoder decoder;
+
 };
+
 #endif // VIDEOPROCESSOR_H

--- a/QtImageViewer/VideoProcessor.hpp
+++ b/QtImageViewer/VideoProcessor.hpp
@@ -8,7 +8,7 @@
 
 #include <QObject>
 #include <QPixmap>
-
+#include <QThread>
 
 /**
  * @brief The VideoProcessor class
@@ -29,6 +29,10 @@ public:
 
     ~VideoProcessor();
 
+    /**
+     * This method is called once after calling polysync::Node::connectPolySync.
+     * It is used here to register as a listener for image data messaages.
+     */
     void initStateEvent() override;
 
     /**
@@ -67,6 +71,13 @@ private:
 
     polysync::VideoDecoder decoder;
 
+    QThread thread;
+
+    static constexpr auto IMAGE_WIDTH = 320;
+
+    static constexpr auto IMAGE_HEIGHT = 240;
+
+    static constexpr auto FRAME_RATE = 30;
 };
 
 #endif // VIDEOPROCESSOR_H

--- a/QtImageViewer/VideoViewer.cpp
+++ b/QtImageViewer/VideoViewer.cpp
@@ -4,8 +4,6 @@
 #include <QHBoxLayout>
 #include <QLabel>
 
-#include <iostream>
-
 
 VideoViewer::VideoViewer()
     :
@@ -13,10 +11,11 @@ VideoViewer::VideoViewer()
     _label( new QLabel( this ) )
 {
     // Set viewing window to an appropriate size.
-    resize( 640, 480 );
+    resize( 320, 240 );
 
     // Add layout element to this widget.
     setLayout( _layout );
+
     _label = new QLabel( this );
 
     // Add label to this widget. The label contains the QPixmap that we update.
@@ -26,8 +25,11 @@ VideoViewer::VideoViewer()
     show();
 }
 
-void VideoViewer::slotUpdatePixmap( const QPixmap &pixmap )
+void VideoViewer::slotUpdatePixmap( const QPixmap & pixmap )
 {
-    // Update the view
-    _label->setPixmap( pixmap );
+    if( not pixmap.isNull() )
+    {
+        // Update the view
+        _label->setPixmap( pixmap );
+    }
 }

--- a/QtImageViewer/VideoViewer.hpp
+++ b/QtImageViewer/VideoViewer.hpp
@@ -25,6 +25,7 @@ public:
      */
     VideoViewer();
 
+
 public slots:
 
     /**
@@ -33,9 +34,13 @@ public slots:
      */
     void slotUpdatePixmap( const QPixmap & pixmap );
 
+
 private:
-    QHBoxLayout * _layout{ nullptr };
-    QLabel * _label{ nullptr };
+
+    QHBoxLayout * _layout;
+
+    QLabel * _label;
+
 };
 
 

--- a/QtImageViewer/VideoViewer.hpp
+++ b/QtImageViewer/VideoViewer.hpp
@@ -3,7 +3,6 @@
 
 #include <QWidget>
 
-class QPixmap;
 class QHBoxLayout;
 class QLabel;
 
@@ -20,7 +19,6 @@ class VideoViewer : public QWidget
 public:
 
     /**
-     * @brief VideoViewer ctor
      * Allocates resources for @ref _label and @ref _layout, then adds them
      * to this widget. Calls QWidget::show() to make the widget appear on
      * screen.
@@ -30,17 +28,14 @@ public:
 public slots:
 
     /**
-     * @brief slotUpdatePixmap
      * Triggered from VideoProcessor when new data is available to render.
      * @param [in] pixmap Updated pixmap to render on @ref _label.
      */
     void slotUpdatePixmap( const QPixmap & pixmap );
 
 private:
-    /** @{ GUI Elements */
     QHBoxLayout * _layout{ nullptr };
     QLabel * _label{ nullptr };
-    /** @} */
 };
 
 

--- a/QtImageViewer/main.cpp
+++ b/QtImageViewer/main.cpp
@@ -1,11 +1,8 @@
 #include <QApplication>
-#include <QThread>
 #include <QTimer>
 
 #include "VideoProcessor.hpp"
 #include "VideoViewer.hpp"
-
-#include <memory>
 
 
 int main( int argc, char *argv[] )
@@ -13,32 +10,18 @@ int main( int argc, char *argv[] )
     // Object required to execute Qt GUI functionality
     QApplication app( argc, argv );
 
-    auto videoProcessor =
-            std::unique_ptr< VideoProcessor >( new VideoProcessor );
+    VideoProcessor videoProcessor;
 
-    // Thread video processing loop, this will continously pull data from
-    // a video device and send a QPixmap to the VideoViewer object for rendering.
-    QThread * processingThread = new QThread;
-    videoProcessor->moveToThread( processingThread );
-    processingThread->start();
-
-    auto videoViewer =
-            std::unique_ptr< VideoViewer >( new VideoViewer );
+    VideoViewer videoViewer;
 
     // Qt signal/slot connect for passing data between processor and viewer.
-    QObject::connect( videoProcessor.get(), &VideoProcessor::signalPixmap,
-                      videoViewer.get(), &VideoViewer::slotUpdatePixmap );
+    QObject::connect( &videoProcessor, &VideoProcessor::signalPixmap,
+                      &videoViewer, &VideoViewer::slotUpdatePixmap );
 
     // Start processing in fifty milliseconds, this allows for the next line of
     // code to be called, spawning the Qt application context.
-    QTimer::singleShot( 50/*ms*/, videoProcessor.get(), SLOT( slotRun() ) );
+    QTimer::singleShot( 50/*ms*/, &videoProcessor, SLOT( slotRun() ) );
 
     // Blocking loop until the Viewer widget is closed.
-    int appReturn = app.exec();
-
-    // Halt thread execution and release dynamic memory
-    processingThread->requestInterruption();
-    processingThread->deleteLater();
-
-    return appReturn;
+    app.exec();
 }

--- a/QtImageViewer/main.cpp
+++ b/QtImageViewer/main.cpp
@@ -5,22 +5,16 @@
 #include "VideoProcessor.hpp"
 #include "VideoViewer.hpp"
 
-#warning "Qt natively supports the MJPEG pixel format; a decoder is required for other pixel formats"
-
 #include <memory>
 
-using namespace std;
 
 int main( int argc, char *argv[] )
 {
-    cout << "Qt natively supports the MJPEG pixel format; a decoder is required" <<
-            "for other incoming source pixel formats" << endl;
-
     // Object required to execute Qt GUI functionality
     QApplication app( argc, argv );
 
     auto videoProcessor =
-            unique_ptr< VideoProcessor >( new VideoProcessor );
+            std::unique_ptr< VideoProcessor >( new VideoProcessor );
 
     // Thread video processing loop, this will continously pull data from
     // a video device and send a QPixmap to the VideoViewer object for rendering.
@@ -29,7 +23,7 @@ int main( int argc, char *argv[] )
     processingThread->start();
 
     auto videoViewer =
-            unique_ptr< VideoViewer >( new VideoViewer );
+            std::unique_ptr< VideoViewer >( new VideoViewer );
 
     // Qt signal/slot connect for passing data between processor and viewer.
     QObject::connect( videoProcessor.get(), &VideoProcessor::signalPixmap,


### PR DESCRIPTION
Prior example was not functioning for MJPEG. This commit
adds the use of a polysync::VideoDecoder object to properly
decode incoming compressed data from MJPEG to RGB24.