### PR TITLE
Fix/core 140 logsession import does not compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+*txt.user

--- a/LogSessionImport/CMakeLists.txt
+++ b/LogSessionImport/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
 )
 
 add_executable( ${PROJECT_NAME}
+    main.cpp
     LogSessionImport.cpp
 )
 

--- a/LogSessionImport/LogSessionImport.cpp
+++ b/LogSessionImport/LogSessionImport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 HARBRICK TECHNOLOGIES, INC
+ * Copyright (c) 2015 PolySync
  *
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LogSessionImport/LogSessionImport.cpp
+++ b/LogSessionImport/LogSessionImport.cpp
@@ -22,156 +22,112 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-/**
- * \example LogSessionImport.cpp
- *
- * Log session import example.
- *
- * Demonstrates how to use the PolySync log session transfer API to import a previously
- * exported log session to a new distributed system.
- *
- */
-
-#include <iostream>
-
-#include <PolySyncCore.hpp>
-#include <PolySyncDataModel.hpp>
 #include <PolySyncApplication.hpp>
-#include <PolySyncLogSessionTransfer.hpp>
+#include <PolySyncDataModel.hpp>
+
+#include "LogSessionImport.hpp"
 
 
-using namespace std;
-using namespace polysync;
-using namespace datamodel;
-
-/**
- * @brief SessionImportExample class
- */
-class SessionImportExample : public DataSubscriber
+SessionImportExample::SessionImportExample( const std::string & sessionPath )
+    :
+    _sessionPath( sessionPath ),
+    _importer()
 {
+    // Subscribe to ApplicationEventMessage to determine when
+    // the application connects to the PolySync bus.
+    connectSubscriberMethod< SessionImportExample >(
+            polysync::ApplicationEventMessage::getName(),
+            &SessionImportExample::handleEvent,
+            this );
 
-public:
+    polysync::Application::getInstance()->attachSubscriber( this );
+}
 
-    SessionImportExample( int sessionId )
-        :
-        _sessionId( sessionId )
+
+void SessionImportExample::handleEvent(
+        std::shared_ptr< polysync::Message > message )
+{
+    if( auto event = polysync::datamodel::getSubclass<
+            polysync::ApplicationEventMessage >( message ) )
     {
-        // Subscribe to ApplicationEventMessage to determine when
-        // the application connects to the PolySync bus.
-        connectSubscriberMethod< SessionImportExample >(
-                ApplicationEventMessage::getName(),
-                &SessionImportExample::handleEvent,
-                this );
+        auto eventKind = event->getEventKind();
 
-        _application = Application::getInstance();
-
-        _application->attachSubscriber( this );
-    }
-
-
-private:
-
-    void handleEvent( shared_ptr< Message > message )
-    {
-        if( auto event = getSubclass< ApplicationEventMessage >( message ) )
+        if( eventKind == polysync::EventKind::Init )
         {
-            if( event->getEventKind() == EventKind::Init )
+            // This is the actual usage of the import API.
+            _importer = std::unique_ptr< polysync::LogSessionImport >{
+                    new polysync::LogSessionImport( _sessionPath ) };
+
+            //
+            // Assign imported nodes to new destination host.
+            //
+
+            // Destination hosts are specified using 'LogSessionTransferTarget'.
+            // The import API requires the transfer target to provide one of
+            // the following:
+            // * Interface Address String ("127.0.0.1")
+            // * Manager GUID (562950866709306)
+            // * Host's Id in the SDF
+            polysync::LogSessionTransferTarget transferTarget;
+
+            for( const auto & availableNode : _importer->getAvailableNodes() )
             {
-                // This is the actual usage of the import API.
-                _importer = new LogSessionImport( _sessionId );
+                std::cout << "assigning "
+                          << availableNode.getName()
+                          << " to 127.0.0.1" << std::endl;
 
-                //
-                // Assign imported nodes to new destination host.
-                //
+                transferTarget.setInterfaceAddress("127.0.0.1");
 
-                // Destination hosts are specified using 'LogSessionTransferTarget'.
-                // The import API requires the transfer target to provide one of the following:
-                // * Interface Address String ("127.0.0.1")
-                // * Manager GUID (562950866709306)
-                // * Host's Id in the SDF
-                LogSessionTransferTarget transferTarget;
-
-                for( const auto & availableNode : _importer->getAvailableNodes() )
-                {
-                    cout << "assigning " << availableNode.getName() << " to 127.0.0.1" << endl;
-
-                    transferTarget.setInterfaceAddress("127.0.0.1");
-
-                    _importer->updateNodeTarget(
-                            transferTarget,
-                            availableNode );
-                }
-
-                // Import can be started with or without a progress callback.
-                // When complete, results will be located at "PSYNC_HOME/rnr_logs/[sessionId]"
-                _importer->start(
-                        this,
-                        &SessionImportExample::handleTransferStatus );
+                _importer->updateNodeTarget(
+                        transferTarget,
+                        availableNode );
             }
+
+            // Import can be started with or without a progress callback.
+            // When complete, results will be located at
+            // "PSYNC_HOME/rnr_logs/[sessionId]"
+            _importer->start(
+                    this,
+                    &SessionImportExample::handleTransferStatus );
         }
     }
+}
 
 
-    void handleTransferStatus(
-            const LogSessionTransferStatus & status )
-    {
-        // Status has other information available as well
-        auto state = status.getState();
-
-        cout << "State: ";
-
-        switch( state )
-        {
-            case LogSessionTransferState::Invalid :
-                cout << "Invalid" << endl;
-                break;
-            case LogSessionTransferState::Error :
-                cout << "Error" << endl;
-                break;
-            case LogSessionTransferState::Initial :
-                cout << "Initial" << endl;
-                break;
-            case LogSessionTransferState::Enumeration :
-                cout << "Enumeration" << endl;
-                break;
-            case LogSessionTransferState::TransferringSystemFiles :
-                cout << "TransferringSystemFiles" << endl;
-                break;
-            case LogSessionTransferState::TransformingSystemFile :
-                cout << "TransformingSystemFile" << endl;
-                break;
-            case LogSessionTransferState::TransferringLogfiles :
-                cout << "TransferringLogfiles" << endl;
-                break;
-            case LogSessionTransferState::Complete :
-                cout << "Complete" << endl;
-                _application->disconnectPolySync();
-                break;
-        }
-    }
-
-    int _sessionId;
-
-    LogSessionImport * _importer;
-
-    Application * _application;
-};
-
-
-int main( int argc, char ** argv )
+void SessionImportExample::handleTransferStatus(
+        const polysync::LogSessionTransferState state,
+        const std::shared_ptr< polysync::datamodel::FileSyncStatusMessage > & )
 {
-    if( argc != 2 )
+    std::cout << "State: ";
+
+    switch( state )
     {
-        cerr << "Usage: " << argv[ 0 ] << " [sessionId]" << endl;
-        return -1;
+        case polysync::LogSessionTransferState::Invalid :
+            std::cout << "Invalid" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Error :
+            std::cout << "Error" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Initial :
+            std::cout << "Initial" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Enumeration :
+            std::cout << "Enumeration" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::TransferringSystemFiles :
+            std::cout << "TransferringSystemFiles" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::TransformingSystemFile :
+            std::cout << "TransformingSystemFile" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::TransferringLogfiles :
+            std::cout << "TransferringLogfiles" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Complete :
+            std::cout << "Complete" << std::endl;
+            polysync::Application::getInstance()->disconnectPolySync();
+            break;
+        default:
+            std::cout << "Unknown" << std::endl;
     }
-
-    SessionImportExample importExample{ atoi( argv[ 1 ] ) };
-
-    auto application = Application::getInstance();
-
-    application->setNodeName( "polysync-log-session-import-cpp" );
-
-    application->connectPolySync();
 }

--- a/LogSessionImport/LogSessionImport.hpp
+++ b/LogSessionImport/LogSessionImport.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 HARBRICK TECHNOLOGIES, INC
+ * Copyright (c) 2015 PolySync
  *
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LogSessionImport/LogSessionImport.hpp
+++ b/LogSessionImport/LogSessionImport.hpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015 HARBRICK TECHNOLOGIES, INC
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * \example LogSessionImport.hpp
+ *
+ * Log session import example.
+ *
+ * Demonstrates how to use the PolySync log session transfer API to import a previously
+ * exported log session to a new distributed system.
+ *
+ */
+
+#ifndef LOGSESSIONIMPORT_HPP
+#define LOGSESSIONIMPORT_HPP
+
+
+#include <PolySyncDataSubscriber.hpp>
+#include <PolySyncLogSessionTransfer.hpp>
+
+#include "LogSessionImport.hpp"
+
+
+class SessionImportExample : public polysync::DataSubscriber
+{
+
+public:
+
+    SessionImportExample( const std::string & sessionPath );
+
+
+private:
+
+    void handleEvent( std::shared_ptr< polysync::Message > message );
+
+    void handleTransferStatus(
+            const polysync::LogSessionTransferState status,
+            const std::shared_ptr<
+                polysync::datamodel::FileSyncStatusMessage > & statusMsg);
+
+    const std::string _sessionPath;
+
+    std::unique_ptr< polysync::LogSessionImport > _importer;
+
+};
+
+
+#endif // LOGSESSIONIMPORT_HPP
+

--- a/LogSessionImport/main.cpp
+++ b/LogSessionImport/main.cpp
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2015 PolySync
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 #include <iostream>
 
 #include <PolySyncApplication.hpp>

--- a/LogSessionImport/main.cpp
+++ b/LogSessionImport/main.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+
+#include <PolySyncApplication.hpp>
+
+#include "LogSessionImport.hpp"
+
+
+int main( int argc, char * argv[] )
+{
+    if( argc != 2 )
+    {
+        std::cerr << "Usage: " << argv[ 0 ] << " [sessionId]" << std::endl;
+        return -1;
+    }
+
+    SessionImportExample importExample{ argv[ 1 ] };
+
+    auto application = polysync::Application::getInstance();
+
+    application->setNodeName( "polysync-log-session-import-cpp" );
+
+    application->connectPolySync();
+}


### PR DESCRIPTION
This PR updates the example to use the correct features provided by the C++ API.

Due to existing bugs in C++ API, this example currently only imports the *.sdf file. Addressing this functionality is in progress.