### PR TITLE
Fix LogSessionExport compilation.

### DIFF
--- a/LogSessionExport/CMakeLists.txt
+++ b/LogSessionExport/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
 )
 
 add_executable( ${PROJECT_NAME}
+    main.cpp
     LogSessionExport.cpp
 )
 

--- a/LogSessionExport/LogSessionExport.cpp
+++ b/LogSessionExport/LogSessionExport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 HARBRICK TECHNOLOGIES, INC
+ * Copyright (c) 2015 PolySync
  *
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LogSessionExport/LogSessionExport.cpp
+++ b/LogSessionExport/LogSessionExport.cpp
@@ -22,115 +22,93 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-/**
- * \example LogSessionExport.cpp
- *
- * Log session export example.
- *
- * Demonstrates how to use the PolySync log session transfer API to export a previously
- * recorded log session from a new distributed system.
- *
- */
-
 #include <iostream>
+
+#include <PolySyncApplication.hpp>
 #include <PolySyncCore.hpp>
 #include <PolySyncDataModel.hpp>
-#include <PolySyncApplication.hpp>
-#include <PolySyncLogSessionTransfer.hpp>
 
-using namespace std;
-using namespace polysync;
-using namespace datamodel;
+#include "LogSessionExport.hpp"
 
-/**
- * @brief SessionExportExample class
- */
-class SessionExportExample : public DataSubscriber
+
+SessionExportExample::SessionExportExample(
+        int sessionId,
+        const std::string & sessionPath )
+    :
+    _sessionId( sessionId ),
+    _sessionPath( sessionPath ),
+    _exporter()
 {
+    // Subscribe to ApplicationEventMessage to determine when
+    // the application connects to the PolySync bus.
+    connectSubscriberMethod< SessionExportExample >(
+            polysync::ApplicationEventMessage::getName(),
+            &SessionExportExample::handleEvent,
+            this );
 
-public:
+    polysync::Application::getInstance()->attachSubscriber( this );
+}
 
-    SessionExportExample(
-            int sessionId )
-        :
-        _sessionId( sessionId )
+
+void SessionExportExample::handleEvent(
+        std::shared_ptr< polysync::Message > message )
+{
+    if( auto event = polysync::datamodel::getSubclass<
+                polysync::ApplicationEventMessage >( message ) )
     {
-        // Subscribe to ApplicationEventMessage to determine when
-        // the application connects to the PolySync bus.
-        connectSubscriberMethod< SessionExportExample >(
-                ApplicationEventMessage::getName(),
-                &SessionExportExample::handleEvent,
-                this );
-
-        _application = Application::getInstance();
-
-        _application->attachSubscriber( this );
-    }
-
-private:
-
-    void handleEvent( shared_ptr< Message > message )
-    {
-        if( auto event = getSubclass< ApplicationEventMessage >( message ) )
+        if( event->getEventKind() == polysync::EventKind::Init )
         {
-            if( event->getEventKind() == EventKind::Init )
-            {
-                // This is the actual usage of the export API.
-                _exporter = new LogSessionExport( _sessionId );
+            // This is the actual usage of the export API.
+            _exporter = std::unique_ptr< polysync::LogSessionExport >{
+                    new polysync::LogSessionExport{
+                        _sessionId, _sessionPath } };
 
-                // Export can be started with or without a progress callback.
-                // When complete, results will be located at "PSYNC_HOME/rnr_logs/export/[sessionId]"
-                _exporter->start(
-                        this,
-                        &SessionExportExample::handleTransferStatus );
-            }
+            // Export can be started with or without a progress callback.
+            // When complete, results will be located at
+            // "PSYNC_HOME/rnr_logs/export/[sessionId]"
+            _exporter->start(
+                    this,
+                    &SessionExportExample::handleTransferStatus );
         }
     }
-
-    void handleTransferStatus(
-            const LogSessionTransferStatus & status )
-    {
-        // Status has other information available as well
-        auto state = status.getState();
-
-        cout << "State: ";
-
-        switch( state )
-        {
-            case LogSessionTransferState::Invalid : cout << "Invalid" << endl; break;
-            case LogSessionTransferState::Error : cout << "Error" << endl; break;
-            case LogSessionTransferState::Initial : cout << "Initial" << endl; break;
-            case LogSessionTransferState::Enumeration : cout << "Enumeration" << endl; break;
-            case LogSessionTransferState::TransferringSystemFiles : cout << "TransferringSystemFiles" << endl; break;
-            case LogSessionTransferState::TransformingSystemFile : cout << "TransformingSystemFile" << endl; break;
-            case LogSessionTransferState::TransferringLogfiles : cout << "TransferringLogfiles" << endl; break;
-            case LogSessionTransferState::Complete : cout << "Complete" << endl; _application->disconnectPolySync(); break;
-        }
-    }
-
-    int _sessionId;
-
-    LogSessionExport * _exporter;
-
-    Application * _application;
-
-};
+}
 
 
-int main( int argc, char ** argv )
+void SessionExportExample::handleTransferStatus(
+        const polysync::LogSessionTransferState state,
+        const std::shared_ptr< polysync::datamodel::FileSyncStatusMessage > & )
 {
-    if( argc != 2 )
+    std::cout << "State: ";
+
+    switch( state )
     {
-        cerr << "Usage: " << argv[0] << " [sessionId]" << endl;
-        return -1;
+        case polysync::LogSessionTransferState::Invalid:
+            std::cout << "Invalid" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Error:
+            std::cout << "Error" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Initial:
+            std::cout << "Initial" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Enumeration:
+            std::cout << "Enumeration" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::TransferringSystemFiles:
+            std::cout << "TransferringSystemFiles" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::TransformingSystemFile:
+            std::cout << "TransformingSystemFile" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::TransferringLogfiles:
+            std::cout << "TransferringLogfiles" << std::endl;
+            break;
+        case polysync::LogSessionTransferState::Complete:
+            std::cout << "Complete" << std::endl;
+            polysync::Application::getInstance()->disconnectPolySync();
+            break;
+        default:
+            std::cout << "Unknown polysync::LogSessionTransferState"
+                      << std::endl;
     }
-
-    SessionExportExample exportExample{ atoi(argv[1]) };
-
-    auto application = Application::getInstance();
-
-    application->setNodeName( "polysync-log-session-export-cpp" );
-
-    application->connectPolySync();
 }

--- a/LogSessionExport/LogSessionExport.hpp
+++ b/LogSessionExport/LogSessionExport.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 HARBRICK TECHNOLOGIES, INC
+ * Copyright (c) 2015 PolySync
  *
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LogSessionExport/LogSessionExport.hpp
+++ b/LogSessionExport/LogSessionExport.hpp
@@ -48,7 +48,6 @@ public:
     SessionExportExample(
             int sessionId, const std::string & sessionPath = {} );
 
-    ~SessionExportExample(){ std::cout << "dtor" << std::endl; }
 private:
 
     void handleEvent( std::shared_ptr< polysync::Message > message );

--- a/LogSessionExport/LogSessionExport.hpp
+++ b/LogSessionExport/LogSessionExport.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 HARBRICK TECHNOLOGIES, INC
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * \example LogSessionExport.hpp
+ *
+ * Log session export example.
+ *
+ * Demonstrates how to use the PolySync log session transfer API to export a previously
+ * recorded log session from a new distributed system.
+ *
+ */
+
+#ifndef LOGSESSIONEXPORT_HPP
+#define LOGSESSIONEXPORT_HPP
+
+
+#include <PolySyncLogSessionTransfer.hpp>
+#include <PolySyncDataSubscriber.hpp>
+
+
+class SessionExportExample : public polysync::DataSubscriber
+{
+
+public:
+
+    SessionExportExample(
+            int sessionId, const std::string & sessionPath = {} );
+
+    ~SessionExportExample(){ std::cout << "dtor" << std::endl; }
+private:
+
+    void handleEvent( std::shared_ptr< polysync::Message > message );
+
+    void handleTransferStatus(
+            const polysync::LogSessionTransferState state,
+            const std::shared_ptr< polysync::datamodel::FileSyncStatusMessage > & );
+
+    const ps_rnr_session_id _sessionId;
+
+    const std::string & _sessionPath;
+
+    std::unique_ptr< polysync::LogSessionExport > _exporter;
+
+};
+
+
+#endif // LOGSESSIONEXPORT_HPP
+

--- a/LogSessionExport/LogSessionExport.hpp
+++ b/LogSessionExport/LogSessionExport.hpp
@@ -58,7 +58,7 @@ private:
 
     const ps_rnr_session_id _sessionId;
 
-    const std::string & _sessionPath;
+    const std::string _sessionPath;
 
     std::unique_ptr< polysync::LogSessionExport > _exporter;
 

--- a/LogSessionExport/main.cpp
+++ b/LogSessionExport/main.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 PolySync
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <iostream>
+
+#include <PolySyncApplication.hpp>
+
+#include "LogSessionExport.hpp"
+
+
+int main( int argc, char * argv[] )
+{
+    if( argc < 2 )
+    {
+        std::cerr << "Usage: " << argv[0] << " [sessionId]" << std::endl;
+        return -1;
+    }
+
+    auto sessionId = std::atoi( argv[1] );
+
+    std::unique_ptr< SessionExportExample > exportExample;
+
+    if( sessionId != 0 )
+    {
+        if( argc == 3 )
+        {
+            exportExample = std::unique_ptr< SessionExportExample >{
+                        new SessionExportExample{ sessionId, argv[2] } };
+        }
+        else
+        {
+            exportExample = std::unique_ptr< SessionExportExample >{
+                    new SessionExportExample{ sessionId } };
+        }
+    }
+
+    auto application = polysync::Application::getInstance();
+
+    application->setNodeName( "polysync-log-session-export-cpp" );
+
+    application->connectPolySync();
+}


### PR DESCRIPTION
Prior commit was not compiling. This was because the example was
using outdated API code.

Closes Core-141