### PR TITLE
Add qt.conf file to build instructions

### DIFF
--- a/QtImageViewer/README.md
+++ b/QtImageViewer/README.md
@@ -32,8 +32,16 @@ A Qt install and mesa-common-dev Debian package are required to run this example
 
     `sudo apt install mesa-common-dev`
 
+6. Follow the build instructions.
+
+7. After building the QtImageViewer, move a qt.conf file into the build file for the QtImageViewer. 
+
+8. Run the node.
+
 
 ### Building and running the node
+
+#### Build
 
 ```bash
 # Tell cmake where to find Qt, note that the path listed below may be different (your version may not be 5.8)
@@ -42,8 +50,12 @@ $ cd QtImageViewer
 $ mkdir build && cd build
 $ cmake ..
 $ make
-$ ./polysync-qt-image-viewer-cpp
 ```
+
+#### Run
+
+`$ ./polysync-qt-image-viewer-cpp`
+
 
 For more API examples, visit the "Tutorials" and "Development" sections in the PolySync Help Center [here](https://help.polysync.io/articles/).
 

--- a/QtImageViewer/README.md
+++ b/QtImageViewer/README.md
@@ -35,6 +35,7 @@ A Qt install and mesa-common-dev Debian package are required to run this example
 6. Follow the build instructions.
 
 7. After building the QtImageViewer, move a qt.conf file into the build file for the QtImageViewer. 
+ - The qt.conf file overrides the hard coded paths compiled into the QT library
 
 8. Run the node.
 


### PR DESCRIPTION
Before this commit, the build instructions did not tell the user to copy a qt.conf file
into the build directory. This prevented the QtImageViewer from functioning properly.
This commit fixes that by updating the Readme to contain the appropriate instructions.