### PR TITLE
Replaced deprecated C++ functions

### DIFF
--- a/Echo/EchoNode.cpp
+++ b/Echo/EchoNode.cpp
@@ -105,7 +105,7 @@ void PolySyncEcho::tryCatchRegisterAMessageListener( std::string messageName )
 
 void PolySyncEcho::messageEvent( std::shared_ptr< polysync::Message > message )
 {
-    if( ( message->getSourceGuid() == getGuid() ) &&
+    if( ( message->getHeaderSrcGuid() == getGuid() ) &&
         _inputHandler.ignoreSelfWasRequested()  )
     {
         return;

--- a/LogfileReader/LogfileReaderExample.cpp
+++ b/LogfileReader/LogfileReaderExample.cpp
@@ -163,7 +163,7 @@ void LogfileReaderNode::messageEvent(
 {
     if( message )
     {
-        if( message->getMessageTypeString() == "ps_byte_array_msg" )
+        if( message->getHeaderTypeString() == "ps_byte_array_msg" )
         {
             ++_numMessagesRead;
 

--- a/LogfileReader/README.md
+++ b/LogfileReader/README.md
@@ -6,7 +6,7 @@ Even though it depends on a file in the `/tmp/` directory, it can still be easil
 
 Steps to run: 
 
-   1. Update the file `src/logfile_reader.c` on line 74 to point to an existing `plog` file, (point to new rnr_logs location)
+   1. Update the file `LogfileReaderExample.hpp` on line 108 to point to an existing `plog` file, (point to new rnr_logs location)
    2. Compile
    3. Run
 


### PR DESCRIPTION
Prior to this commit

EchoNode.cpp was using `getSourceGuid()` replaced with `getHeaderSrcGuid()`

LogfileReaderExample.cpp was using `getMessageTypeString()` replaced with `getHeaderTypeString()`

Updated the LogfileReader's README.md to update the correct file.  It was using a c file.