### PR TITLE
Update example to phase out deprecated function

### DIFF
--- a/Echo/EchoNode.cpp
+++ b/Echo/EchoNode.cpp
@@ -106,11 +106,7 @@ void PolySyncEcho::tryCatchRegisterAMessageListener( std::string messageName )
 void PolySyncEcho::messageEvent( std::shared_ptr< polysync::Message > message )
 {
     if( ( message->getHeaderSrcGuid() == getGuid() ) &&
-<<<<<<< HEAD
         _inputHandler.ignoreSelfWasRequested() )
-=======
-        _inputHandler.ignoreSelfWasRequested()  )
->>>>>>> 62533412f54c20a048841a543afee0ccb8019bbb
     {
         return;
     }

--- a/Echo/EchoNode.cpp
+++ b/Echo/EchoNode.cpp
@@ -105,8 +105,8 @@ void PolySyncEcho::tryCatchRegisterAMessageListener( std::string messageName )
 
 void PolySyncEcho::messageEvent( std::shared_ptr< polysync::Message > message )
 {
-    if( ( message->getSourceGuid() == getGuid() ) &&
-        _inputHandler.ignoreSelfWasRequested()  )
+    if( ( message->getHeaderSrcGuid() == getGuid() ) &&
+        _inputHandler.ignoreSelfWasRequested() )
     {
         return;
     }


### PR DESCRIPTION
Prior to this commit this examples output reported
`WARN   [-] - polysync::Message::getSourceGuid() is deprecated. Use polysync::Message::getHeaderSrcGuid(). This method will be removed.`.

This commit updates the code accordingly so the example is no longer using a deprecated function and the warning goes away.