### PR TITLE
Update import/export example logic

### DIFF
--- a/LogSessionExport/LogSessionExport.hpp
+++ b/LogSessionExport/LogSessionExport.hpp
@@ -46,7 +46,8 @@ class SessionExportExample : public polysync::DataSubscriber
 public:
 
     SessionExportExample(
-            int sessionId, const std::string & sessionPath = {} );
+            ps_rnr_session_id sessionId,
+            const std::string & sessionPath = {} );
 
 private:
 
@@ -62,6 +63,7 @@ private:
 
     std::unique_ptr< polysync::LogSessionExport > _exporter;
 
+    bool _transferComplete;
 };
 
 

--- a/LogSessionExport/main.cpp
+++ b/LogSessionExport/main.cpp
@@ -37,7 +37,7 @@ int main( int argc, char * argv[] )
         return -1;
     }
 
-    auto sessionId = std::atoi( argv[1] );
+    auto sessionId = std::stoull( argv[1] );
 
     std::unique_ptr< SessionExportExample > exportExample;
 

--- a/LogSessionImport/LogSessionImport.cpp
+++ b/LogSessionImport/LogSessionImport.cpp
@@ -31,7 +31,8 @@
 SessionImportExample::SessionImportExample( const std::string & sessionPath )
     :
     _sessionPath( sessionPath ),
-    _importer()
+    _importer(),
+    _transferComplete( false )
 {
     // Subscribe to ApplicationEventMessage to determine when
     // the application connects to the PolySync bus.
@@ -90,6 +91,11 @@ void SessionImportExample::handleEvent(
                     this,
                     &SessionImportExample::handleTransferStatus );
         }
+        else if( eventKind == polysync::EventKind::Ok && _transferComplete )
+        {
+            _importer.reset();
+            polysync::Application::getInstance()->disconnectPolySync();
+        }
     }
 }
 
@@ -107,6 +113,7 @@ void SessionImportExample::handleTransferStatus(
             break;
         case polysync::LogSessionTransferState::Error :
             std::cout << "Error" << std::endl;
+            polysync::Application::getInstance()->disconnectPolySync();                        
             break;
         case polysync::LogSessionTransferState::Initial :
             std::cout << "Initial" << std::endl;
@@ -125,7 +132,7 @@ void SessionImportExample::handleTransferStatus(
             break;
         case polysync::LogSessionTransferState::Complete :
             std::cout << "Complete" << std::endl;
-            polysync::Application::getInstance()->disconnectPolySync();
+            _transferComplete = true;
             break;
         default:
             std::cout << "Unknown" << std::endl;

--- a/LogSessionImport/LogSessionImport.hpp
+++ b/LogSessionImport/LogSessionImport.hpp
@@ -63,7 +63,8 @@ private:
     const std::string _sessionPath;
 
     std::unique_ptr< polysync::LogSessionImport > _importer;
-
+    
+    bool _transferComplete;
 };
 
 


### PR DESCRIPTION
Prior to this commit, LogSessionImport and LogSessionExport examples were reporting errors.
This exposed an existing bug in polysync-core-cpp-api. This commit adds some improvements
to the logic, including resource management for the _importer and _exporter member variables.
Following the bugfix (CORE-653) merge, this commit will enable proper functionality for
LogSessionImport and LogSessionExport examples.