### PR TITLE
Add option to forgo writing to sdtout when writing to file

### DIFF
--- a/Echo/ApplicationInputHandler.cpp
+++ b/Echo/ApplicationInputHandler.cpp
@@ -7,12 +7,12 @@
 
 ApplicationInputHandler::ApplicationInputHandler()
     :
-    _userFileName( {} ),
     _activeMessagesFlag( false ),
     _ignoreSelfFlag( false ),
     _filteredForMessagesFlag( false ),
     _echoMessageHeadersOnlyFlag( false ),
     _echoMessageToFileFlag( false ),
+    _echoMessageToFileNoStdOutFlag( false ),
     _getOptHelpFlag( false ),
     _durationSpecifiedFlag( false ),
     _filteredMessageNames( {} )
@@ -32,7 +32,7 @@ bool ApplicationInputHandler::optionsParse( const int argc, char * argv[] )
 
     opterr = 0;
 
-    while ( ( optionIndex = getopt( argc, argv, "t:o:f:hH::a::i::") ) != -1 )
+    while ( ( optionIndex = getopt( argc, argv, "t:o:O:f:hH::a::i::") ) != -1 )
     {
         switch( optionIndex )
         {
@@ -94,6 +94,32 @@ bool ApplicationInputHandler::optionsParse( const int argc, char * argv[] )
                     _userFileName = optarg;
 
                     _echoMessageToFileFlag = true;
+                }
+
+                break;
+
+            case 'O':
+
+                if( ( *argv[ optind - 1 ] )
+                     && ( *argv[ optind - 1 ] == '-' ) )
+                {
+                    std::cout << std::endl << std::endl
+                         << "Invalid usage for option -O external file:"
+                         << std::endl
+                         << "-O should be followed by a filename "
+                         << "yourfile.txt, not by another -option."
+                         << std::endl << std::endl
+                         << "A usage guide follows."
+                         << std::endl;
+
+                    _getOptHelpFlag = true;
+                }
+                else
+                {
+                    _userFileName = optarg;
+
+                    _echoMessageToFileFlag = true;
+                    _echoMessageToFileNoStdOutFlag = true;
                 }
 
                 break;
@@ -186,6 +212,10 @@ bool ApplicationInputHandler::fileWasSpecified() const
     return _echoMessageToFileFlag;
 }
 
+bool ApplicationInputHandler::fileWasSpecifiedNoStdOut() const
+{
+    return _echoMessageToFileNoStdOutFlag;
+}
 
 bool ApplicationInputHandler::helpWasRequested() const
 {

--- a/Echo/ApplicationInputHandler.cpp
+++ b/Echo/ApplicationInputHandler.cpp
@@ -7,6 +7,7 @@
 
 ApplicationInputHandler::ApplicationInputHandler()
     :
+    _userFileName( {} ),
     _activeMessagesFlag( false ),
     _ignoreSelfFlag( false ),
     _filteredForMessagesFlag( false ),

--- a/Echo/ApplicationInputHandler.hpp
+++ b/Echo/ApplicationInputHandler.hpp
@@ -75,6 +75,13 @@ public:
     /**
      * @brief Member variable getter for command line getopt handling.
      *
+     * @return Returns boolean: true if user specified external file for output
+     * and does wants to forgo reporting to stdout.
+     */
+    bool fileWasSpecifiedNoStdOut() const;
+    /**
+     * @brief Member variable getter for command line getopt handling.
+     *
      * @return Returns boolean: true if user either requested help directly,
      *          or user entered invalid options/arguments on command line.
      *
@@ -127,6 +134,8 @@ private:
     bool _echoMessageHeadersOnlyFlag;
 
     bool _echoMessageToFileFlag;
+
+    bool _echoMessageToFileNoStdOutFlag;
 
     bool _getOptHelpFlag;
 

--- a/Echo/EchoHelp.cpp
+++ b/Echo/EchoHelp.cpp
@@ -13,6 +13,7 @@ std::vector< std::string > EchoHelp::getHelpFlags() const
     cmdLineFlagsHelp.emplace_back( "-f <MESSAGE_TYPE>" );
     cmdLineFlagsHelp.emplace_back( "-H" );
     cmdLineFlagsHelp.emplace_back( "-o <FILE_NAME>" );
+    cmdLineFlagsHelp.emplace_back( "-O <FILE_NAME>" );
     cmdLineFlagsHelp.emplace_back( "-t <ECHO_DURATION [sec]>" );
 
     return cmdLineFlagsHelp;
@@ -65,6 +66,14 @@ std::vector< std::string > EchoHelp::getHelpDescriptions() const
         " in addition to standard output [optional]. \n"
         " Usage Example: print only headers for single message type to file: \n"
         " $ polysync-echo -f ps_lidar_points_msg -H -o yourFileName.txt \n\n"
+        " Note: Unless you specify a new file each time, each session will \n"
+        " append to the end of your specified file.");
+
+    flagDescriptionsHelp.emplace_back
+        ( " Specify an external output file for printed message data \n"
+        " and forgo standard output [optional]. \n"
+        " Usage Example: print only headers for single message type to file: \n"
+        " $ polysync-echo -O yourFileName.txt \n\n"
         " Note: Unless you specify a new file each time, each session will \n"
         " append to the end of your specified file.");
 

--- a/Echo/EchoNode.cpp
+++ b/Echo/EchoNode.cpp
@@ -23,7 +23,10 @@ void PolySyncEcho::initStateEvent()
         registerListenerToAllMessageTypes();
     }
 
-    std::cout << "{\"polysync-echo\":[";
+    if( ! _inputHandler.fileWasSpecifiedNoStdOut() )
+    {
+        std::cout << "{\"polysync-echo\":[";
+    }
 
     if( _inputHandler.fileWasSpecified() )
     {
@@ -32,6 +35,14 @@ void PolySyncEcho::initStateEvent()
         if( _openUserFile )
         {
             _openUserFile << "{\"polysync-echo\":[";
+        }
+        else
+        {
+            std::cerr <<
+            "Unable to open '_inputHandler.getFileName()' for writing" <<
+            std::endl;
+
+            activateFault( DTC_IOERR, NODE_STATE_FATAL);
         }
     }
 }
@@ -64,14 +75,16 @@ void PolySyncEcho::okStateEvent()
 
 void PolySyncEcho::releaseStateEvent()
 {
-    std::cout << "]}" << std::endl;
+    if( ! _inputHandler.fileWasSpecifiedNoStdOut() )
+    {
+        std::cout << "]}" << std::endl;
+    }
 
     if( _openUserFile )
     {
         _openUserFile << "]}" << std::endl;
+        _openUserFile.close();
     }
-
-    _openUserFile.close();
 }
 
 
@@ -116,7 +129,10 @@ void PolySyncEcho::messageEvent( std::shared_ptr< polysync::Message > message )
         printToFile( message );
     }
 
-    printMessage( message );
+    if( ! _inputHandler.fileWasSpecifiedNoStdOut() )
+    {
+        printMessage( message );
+    }
 }
 
 
@@ -140,7 +156,10 @@ void PolySyncEcho::printToFile(
     }
     else
     {
-        message->print( _openUserFile );
+        if( ! _inputHandler.fileWasSpecifiedNoStdOut() )
+        {
+            message->print( _openUserFile );
+        }
     }
 }
 
@@ -156,7 +175,10 @@ void PolySyncEcho::printMessage(
     }
     else
     {
-        std::cout << ",";
+        if( ! _inputHandler.fileWasSpecifiedNoStdOut() )
+        {
+            std::cout << ",";
+        }
     }
 
     if( _inputHandler.headersWereRequested() )

--- a/Echo/EchoNode.cpp
+++ b/Echo/EchoNode.cpp
@@ -156,10 +156,7 @@ void PolySyncEcho::printToFile(
     }
     else
     {
-        if( ! _inputHandler.fileWasSpecifiedNoStdOut() )
-        {
-            message->print( _openUserFile );
-        }
+        message->print( _openUserFile );
     }
 }
 


### PR DESCRIPTION
Prior to this commit this example always wrote to stdout.
This meant the users who were interested in writing to a
specified file were unable to minimize the ammout of IO
work the tool had to do when not interested terminal reporting.

This commit represents the addition of a `-O` option to compliment
the existing `-o`. If `-O` is selected the example will
write to a file and not to stdout as well.

Logic was also added to report an error and activate a fatal
state if the example is unable to open the specified input
file rather that failing silently and maintaining the OK
state.